### PR TITLE
Add additional properties to HTML options

### DIFF
--- a/src/BundlerMinifier/Minify/HtmlOptions.cs
+++ b/src/BundlerMinifier/Minify/HtmlOptions.cs
@@ -1,4 +1,5 @@
-﻿using WebMarkupMin.Core;
+﻿using Newtonsoft.Json.Linq;
+using WebMarkupMin.Core;
 using WebMarkupMin.Core.Settings;
 
 namespace BundlerMinifier
@@ -12,12 +13,14 @@ namespace BundlerMinifier
             settings.RemoveRedundantAttributes = GetValue(bundle, "removeRedundantAttributes") == "True";
 
             settings.CollapseBooleanAttributes = GetValue(bundle, "collapseBooleanAttributes") == "True";
+            settings.CustomAngularDirectiveList = GetValue(bundle, "customAngularDirectiveList");
             settings.MinifyAngularBindingExpressions = GetValue(bundle, "minifyAngularBindingExpressions") == "True";
             settings.MinifyEmbeddedCssCode = GetValue(bundle, "minifyEmbeddedCssCode") == "True";
             settings.MinifyEmbeddedJsCode= GetValue(bundle, "minifyEmbeddedJsCode") == "True";
             settings.MinifyInlineCssCode = GetValue(bundle, "minifyInlineCssCode") == "True";
             settings.MinifyInlineJsCode = GetValue(bundle, "minifyInlineJsCode") == "True";
             settings.MinifyKnockoutBindingExpressions = GetValue(bundle, "minifyKnockoutBindingExpressions") == "True";
+            settings.ProcessableScriptTypeList = GetValue(bundle, "processableScriptTypeList");
             settings.RemoveHtmlComments = GetValue(bundle, "removeHtmlComments") == "True";
             settings.RemoveTagsWithoutContent = GetValue(bundle, "removeTagsWithoutContent") == "True";
 
@@ -36,7 +39,17 @@ namespace BundlerMinifier
         internal static string GetValue(Bundle bundle, string key)
         {
             if (bundle.Minify.ContainsKey(key))
-                return bundle.Minify[key].ToString();
+            {
+                object value = bundle.Minify[key];
+                if (value is JArray)
+                {
+                    return string.Join(",", ((JArray)value).Values<string>());
+                }
+                else
+                {
+                    return value.ToString();
+                }
+            }
 
             return string.Empty;
         }

--- a/src/BundlerMinifierVsix/JSON/bundleconfig-schema.json
+++ b/src/BundlerMinifierVsix/JSON/bundleconfig-schema.json
@@ -65,51 +65,59 @@
 					"type": "object",
 					"properties": {
 						"attributeQuotesRemovalMode": {
-							"description": "HTML only.",
-							"enum": [ "html4", "html5", "keepQuotes" ]
+							"description": "HTML only. Sets the removal mode of HTML attribute quotes.",
+							"enum": [ "html4", "html5", "keepQuotes" ],
+							"default": "html5"
 						},
 						"collapseBooleanAttributes": {
-							"description": "HTML only.",
+							"description": "HTML only. Remove values from boolean attributes.",
 							"type": "boolean"
 						},
+						"customAngularDirectiveList": {
+							"description": "HTML only. Specify array of names of custom Angular.js directives (e.g. [\"myDir\", \"btfCarousel\"]), that contain expressions.",
+							"type": "array"
+						},
 						"minifyAngularBindingExpressions": {
-							"description": "HTML only.",
+							"description": "HTML only. Minify Angular.js binding expressions in double curly brackets and directives.",
 							"type": "boolean"
 						},
 						"minifyEmbeddedCssCode": {
-							"description": "HTML only.",
+							"description": "HTML only. Minify CSS code in style tags.",
 							"type": "boolean"
 						},
 						"minifyEmbeddedJsCode": {
-							"description": "HTML only.",
+							"description": "HTML only. Minify JS code in script tags.",
 							"type": "boolean"
 						},
 						"minifyInlineCssCode": {
-							"description": "HTML only.",
+							"description": "HTML only. Minify CSS code in style attributes.",
 							"type": "boolean"
 						},
 						"minifyInlineJsCode": {
-							"description": "HTML only.",
+							"description": "HTML only. Minify JS code in event attributes and hyperlinks with javascript: pseudo-protocol.",
 							"type": "boolean"
 						},
 						"minifyKnockoutBindingExpressions": {
-							"description": "HTML only.",
+							"description": "HTML only. Minify Knockout.js binding expressions in data-bind attributes and containerless comments.",
 							"type": "boolean"
 						},
+						"processableScriptTypeList": {
+							"description": "HTML only. Specify array of types of script tags, that are processed by minifier (e.g. [\"text/html\", \"text/ng-template\"])."
+						},
 						"removeHtmlComments": {
-							"description": "HTML only.",
+							"description": "HTML only. Remove all HTML comments except conditional, noindex, Knockout.js containerless comments and Angular.js comment directives.",
 							"type": "boolean"
 						},
 						"removeOptionalEndTags": {
-							"description": "HTML only.",
+							"description": "HTML only. Remove optional end tags.",
 							"type": "boolean"
 						},
 						"removeRedundantAttributes": {
-							"description": "HTML only.",
+							"description": "HTML only. Remove redundant attributes.",
 							"type": "boolean"
 						},
 						"removeTagsWithoutContent": {
-							"description": "HTML only.",
+							"description": "HTML only. Remove tags without content (except for textarea, tr, th and td tags, and tags with class, id, name, role, src and data-* attributes).",
 							"type": "boolean"
 						}
 					}

--- a/src/BundlerMinifierVsix/JSON/bundleconfig-schema.json
+++ b/src/BundlerMinifierVsix/JSON/bundleconfig-schema.json
@@ -102,7 +102,8 @@
 							"type": "boolean"
 						},
 						"processableScriptTypeList": {
-							"description": "HTML only. Specify array of types of script tags, that are processed by minifier (e.g. [\"text/html\", \"text/ng-template\"])."
+							"description": "HTML only. Specify array of types of script tags, that are processed by minifier (e.g. [\"text/html\", \"text/ng-template\"]).",
+							"type": "array"
 						},
 						"removeHtmlComments": {
 							"description": "HTML only. Remove all HTML comments except conditional, noindex, Knockout.js containerless comments and Angular.js comment directives.",


### PR DESCRIPTION
Add `CustomAngularDirectiveList` and `ProcessableScriptTypeList` properties to HTML options.