### PR TITLE
Allow Creation Of Output Dirs When Not Exists

### DIFF
--- a/src/BundlerMinifier/Bundle/BundleFileProcessor.cs
+++ b/src/BundlerMinifier/Bundle/BundleFileProcessor.cs
@@ -63,8 +63,12 @@ namespace BundlerMinifier
             string outputFile = Path.Combine(baseFolder, bundle.OutputFileName);
 
             OnBeforeProcess(bundle, baseFolder);
-            Directory.CreateDirectory(outputFile);
+            
+            DirectoryInfo outputFileDirectory = Directory.GetParent(outputFile);
+            outputFileDirectory.Create();
+            
             File.WriteAllText(outputFile, bundle.Output, new UTF8Encoding(true));
+            
             OnAfterProcess(bundle, baseFolder);
 
             if (bundle.Minify.ContainsKey("enabled") && bundle.Minify["enabled"].ToString().Equals("true", StringComparison.OrdinalIgnoreCase))

--- a/src/BundlerMinifier/Bundle/BundleFileProcessor.cs
+++ b/src/BundlerMinifier/Bundle/BundleFileProcessor.cs
@@ -63,6 +63,7 @@ namespace BundlerMinifier
             string outputFile = Path.Combine(baseFolder, bundle.OutputFileName);
 
             OnBeforeProcess(bundle, baseFolder);
+            Directory.CreateDirectory(outputFile);
             File.WriteAllText(outputFile, bundle.Output, new UTF8Encoding(true));
             OnAfterProcess(bundle, baseFolder);
 


### PR DESCRIPTION
Currently when the path specified for "outputFileName" doesn´t exists the BundlerMinifier fail
with an incorrect(actually more unhelpful than incorrect) message about the possibility of a format error....

I really think specifying an output path "a/b/c/d.html" should work even if "a/" doesn´t exists.