### PR TITLE
Support Folder Bundle Update On Save

### DIFF
--- a/src/BundlerMinifier/Bundle/BundleFileProcessor.cs
+++ b/src/BundlerMinifier/Bundle/BundleFileProcessor.cs
@@ -42,16 +42,18 @@ namespace BundlerMinifier
         public void SourceFileChanged(string bundleFile, string sourceFile)
         {
             var bundles = BundleHandler.GetBundles(bundleFile);
-            string folder = Path.GetDirectoryName(bundleFile);
+            string bundleFileFolder = Path.GetDirectoryName(bundleFile),
+                   sourceFileFolder = Path.GetDirectoryName(sourceFile);
 
             foreach (Bundle bundle in bundles)
             {
                 foreach (string inputFile in bundle.InputFiles)
                 {
-                    string input = Path.Combine(folder, inputFile.Replace("/", "\\"));
+                    string input = Path.Combine(bundleFileFolder, inputFile.Replace("/", "\\"));
 
-                    if (input.Equals(sourceFile, System.StringComparison.OrdinalIgnoreCase))
-                        ProcessBundle(folder, bundle);
+                    if (input.Equals(sourceFile, System.StringComparison.OrdinalIgnoreCase)||
+                        input.Equals(sourceFileFolder, System.StringComparison.OrdinalIgnoreCase))
+                        ProcessBundle(bundleFileFolder, bundle);
                 }
             }
         }


### PR DESCRIPTION
This is to make changes to files of a folder bundle Input source to cause a bundle update.
Currently i have to save the bundle(via the context menu), since i don´t use the "MSBuild Support"

I actually think Recursive file globing should be supported as, but right now this fix is for the current top-diretory globbing support.
```javascript
[
    {
        "outputFileName": "www/index.html",
        "inputFiles": [
            "app/_index_begin.html",
            "app/_index.html",
            "app/core/directives/login/",            //---|
            "app/core/directives/userprofile/",           |
            "app/core/directives/userphoto/",             | recursive globbing would make this easier. 
            "app/core/directives/currentuser-name/",//---|
             /*...*/
            "app/_index_end.html"
        ]
    }
] 
```