### PR TITLE
Removing readonly flag before writing to min file

### DIFF
--- a/src/BundlerMinifier/MSBuild/BundlerBuildTask.cs
+++ b/src/BundlerMinifier/MSBuild/BundlerBuildTask.cs
@@ -35,6 +35,7 @@ namespace BundlerMinifier
             BundleFileProcessor processor = new BundleFileProcessor();
             processor.Processing += (s, e) => { RemoveReadonlyFlagFromFile(e.Bundle.GetAbsoluteOutputFile()); };
             processor.AfterBundling += Processor_AfterProcess;
+            BundleMinifier.BeforeWritingMinFile += (s, e) => { RemoveReadonlyFlagFromFile(e.ResultFile); };
             processor.BeforeWritingSourceMap += (s, e) => { RemoveReadonlyFlagFromFile(e.ResultFile); };
             processor.AfterWritingSourceMap += Processor_AfterWritingSourceMap;
             BundleMinifier.ErrorMinifyingFile += BundleMinifier_ErrorMinifyingFile;


### PR DESCRIPTION
I found that on my build server for CI the min file was not being written to because the readonly flag was not first being removed from the file.