### PR TITLE
Fixed crash in CLI when no argument is supplied

### DIFF
--- a/src/BundlerMinifier/Program.cs
+++ b/src/BundlerMinifier/Program.cs
@@ -9,6 +9,12 @@ namespace BundlerMinifier
     {
         static int Main(params string[] args)
         {
+            if (args.Length == 0)
+            {
+                Console.WriteLine("\x1B[33mUsage: BundlerMinifier <configPath> [configFile]");
+                return 0;
+            }
+
             string configPath = args[0];
             string file = args.Length > 1 ? args[1] : null;
             var configs = GetConfigs(configPath, file);


### PR DESCRIPTION
If no argument is supplied from the command line, show info about usage
and exit program.