### PR TITLE
MSBuild BundlerCleanTask

### DIFF
--- a/src/BundlerMinifier/Bundle/BundleFileProcessor.cs
+++ b/src/BundlerMinifier/Bundle/BundleFileProcessor.cs
@@ -40,6 +40,21 @@ namespace BundlerMinifier
             }
         }
 
+        public void DeleteOutputFiles(string bundleFileName)
+        {
+            var bundles = BundleHandler.GetBundles(bundleFileName);
+            foreach (Bundle bundle in bundles)
+            {
+                var outputFile = bundle.GetAbsoluteOutputFile();
+                var minFile = BundleFileProcessor.GetMinFileName(outputFile);
+                var mapFile = minFile + ".map";
+
+                if (File.Exists(outputFile)) File.Delete(outputFile);
+                if (File.Exists(minFile)) File.Delete(minFile);
+                if (File.Exists(mapFile)) File.Delete(mapFile);
+            }
+        }
+
         public void SourceFileChanged(string bundleFile, string sourceFile)
         {
             var bundles = BundleHandler.GetBundles(bundleFile);

--- a/src/BundlerMinifier/BundlerMinifier.csproj
+++ b/src/BundlerMinifier/BundlerMinifier.csproj
@@ -82,6 +82,7 @@
     <Compile Include="Bundle\BundleHandler.cs" />
     <Compile Include="Bundle\BundleFileProcessor.cs" />
     <Compile Include="Minify\MinificationResult.cs" />
+    <Compile Include="MSBuild\BundlerCleanTask.cs" />
     <Compile Include="MSBuild\BundlerBuildTask.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/src/BundlerMinifier/MSBuild/BuildBundlerMinifier.targets
+++ b/src/BundlerMinifier/MSBuild/BuildBundlerMinifier.targets
@@ -9,9 +9,14 @@
     </PropertyGroup>
 
     <UsingTask AssemblyFile="..\tools\BundlerMinifier.exe" TaskName="BundlerMinifier.BundlerBuildTask"/>
+    <UsingTask AssemblyFile="..\tools\BundlerMinifier.exe" TaskName="BundlerMinifier.BundlerCleanTask"/>
 
-    <Target Name="BundleMinify" Condition="'$(RunBundleMinify)' != 'False'">
-        <BundlerMinifier.BundlerBuildTask FileName="$(MSBuildProjectDirectory)\bundleconfig.json" />
-    </Target>
+  <Target Name="BundleMinify" Condition="'$(RunBundleMinify)' != 'False'">
+    <BundlerMinifier.BundlerBuildTask FileName="$(MSBuildProjectDirectory)\bundleconfig.json" />
+  </Target>
+
+  <Target Name="BundleMinifyClean" AfterTargets="CoreClean" Condition="'$(RunBundleMinify)' != 'False'">
+    <BundlerMinifier.BundlerCleanTask FileName="$(MSBuildProjectDirectory)\bundleconfig.json" />
+  </Target>
 
 </Project>

--- a/src/BundlerMinifier/MSBuild/BundlerCleanTask.cs
+++ b/src/BundlerMinifier/MSBuild/BundlerCleanTask.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.IO;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+namespace BundlerMinifier
+{
+    /// <summary>
+    /// An MSBuild task for running web compilers on a given config file.
+    /// </summary>
+    public class BundlerCleanTask : Task
+    {
+        /// <summary>
+        /// The file path of the compilerconfig.json file
+        /// </summary>
+        public string FileName { get; set; }
+
+        /// <summary>
+        /// Execute the Task
+        /// </summary>
+        public override bool Execute()
+        {
+            FileInfo configFile = new FileInfo(FileName);
+
+            Log.LogMessage(MessageImportance.High, Environment.NewLine + "Bundler: Cleaning output from " + configFile.Name);
+
+            if (!configFile.Exists)
+            {
+                Log.LogWarning(configFile.FullName + " does not exist");
+                return true;
+            }
+
+            BundleFileProcessor processor = new BundleFileProcessor();
+            processor.DeleteOutputFiles(configFile.FullName);
+
+            Log.LogMessage(MessageImportance.High, "Bundler: Done cleaning output file from " + configFile.Name);
+
+            return true;
+        }
+        
+    }
+}


### PR DESCRIPTION
Remove all output files when Build>Clean or Build>Rebuild run.