### PR TITLE
Removed duplicate bundles when output file paths are the same

### DIFF
--- a/src/BundlerMinifier/Bundle/BundleHandler.cs
+++ b/src/BundlerMinifier/Bundle/BundleHandler.cs
@@ -9,13 +9,14 @@ namespace BundlerMinifier
 {
     public static class BundleHandler
     {
-        public static void AddBundle(string configFile, Bundle bundle)
+        public static void AddBundle(string configFile, Bundle newBundle)
         {
             IEnumerable<Bundle> existing = GetBundles(configFile);
             List<Bundle> bundles = new List<Bundle>();
-            bundles.AddRange(existing);
-            bundles.Add(bundle);
-            bundle.FileName = configFile;
+
+            bundles.AddRange(existing.Where(x => x.Output != newBundle.Output));
+            bundles.Add(newBundle);
+            newBundle.FileName = configFile;
 
             JsonSerializerSettings settings = new JsonSerializerSettings()
             {


### PR DESCRIPTION
Partially resolves issue https://github.com/madskristensen/BundlerMinifier/issues/77. It will overwrite bundle configurations for existing bundles pointing to the same output location. This would've happened anyway, as when the configuration file was processed it would have overwritten the bundle when seeing the second configuration entry. This just solves the duplicate config file entry.