### PR TITLE
Created bundles overwrite existing bundles with same output path

### DIFF
--- a/src/BundlerMinifier/Bundle/BundleHandler.cs
+++ b/src/BundlerMinifier/Bundle/BundleHandler.cs
@@ -9,13 +9,16 @@ namespace BundlerMinifier
 {
     public static class BundleHandler
     {
-        public static void AddBundle(string configFile, Bundle bundle)
+        public static void AddBundle(string configFile, Bundle newBundle)
         {
-            IEnumerable<Bundle> existing = GetBundles(configFile);
+            IEnumerable<Bundle> existing = GetBundles(configFile)
+                .Where(x => !x.OutputFileName.Equals(newBundle.OutputFileName));
+
             List<Bundle> bundles = new List<Bundle>();
+
             bundles.AddRange(existing);
-            bundles.Add(bundle);
-            bundle.FileName = configFile;
+            bundles.Add(newBundle);
+            newBundle.FileName = configFile;
 
             JsonSerializerSettings settings = new JsonSerializerSettings()
             {


### PR DESCRIPTION
Partially resolves issue https://github.com/madskristensen/BundlerMinifier/issues/77. It will overwrite bundle configurations for existing bundles pointing to the same output location. 

This overwrite would've happened anyway when the configuration file was processed, as it would have overwritten the original bundle's output file contents when processing the new entry.

This could/should be enhanced to provide a dialog box with options to merge/overwrite the existing bundle.