### PR TITLE
Update BundleFileProcessor.cs

### DIFF
--- a/src/BundlerMinifier/Bundle/BundleFileProcessor.cs
+++ b/src/BundlerMinifier/Bundle/BundleFileProcessor.cs
@@ -108,7 +108,7 @@ namespace BundlerMinifier
 
         private void ProcessBundle(string baseFolder, Bundle bundle)
         {
-            var inputLastModified = bundle.GetAbsoluteInputFiles().Concat(new[] { bundle.FileName }).Max(inputFile => File.GetLastWriteTimeUtc(inputFile));
+            var inputLastModified = bundle.GetAbsoluteInputFiles().Max(inputFile => File.GetLastWriteTimeUtc(inputFile));
 
             if ((bundle.GetAbsoluteInputFiles().Count > 1 || bundle.InputFiles.FirstOrDefault() != bundle.OutputFileName)
                 && inputLastModified > File.GetLastWriteTimeUtc(bundle.GetAbsoluteOutputFile()))


### PR DESCRIPTION
Fixes #106. Please review. I have included the details here.

Line 111 in BundleFileProcessor.cs is causing all js files to minify.

var inputLastModified = bundle.GetAbsoluteInputFiles().Concat(new[] { bundle.FileName }).Max(inputFile => File.GetLastWriteTimeUtc(inputFile));

That line is using all input files and getting the max last modified date. Problem is, it is concatenating the bundle file which obviously is newer than all files in the solution. End result minification of all files as the bundle file modified date is greater than min.js file date (line 114).