### PR TITLE
Add `PreserveCase` property to HTML options

### DIFF
--- a/src/BundlerMinifier/BundlerMinifier.csproj
+++ b/src/BundlerMinifier/BundlerMinifier.csproj
@@ -67,8 +67,8 @@
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.XML" />
     <Reference Include="System.Xml.Linq" />
-    <Reference Include="WebMarkupMin.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=99472178d266584b, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\WebMarkupMin.Core.1.0.0\lib\net40\WebMarkupMin.Core.dll</HintPath>
+    <Reference Include="WebMarkupMin.Core, Version=1.1.0.0, Culture=neutral, PublicKeyToken=99472178d266584b, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\WebMarkupMin.Core.1.1.0\lib\net40\WebMarkupMin.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>

--- a/src/BundlerMinifier/Minify/HtmlOptions.cs
+++ b/src/BundlerMinifier/Minify/HtmlOptions.cs
@@ -20,6 +20,7 @@ namespace BundlerMinifier
             settings.MinifyInlineCssCode = GetValue(bundle, "minifyInlineCssCode", true) == "True";
             settings.MinifyInlineJsCode = GetValue(bundle, "minifyInlineJsCode", true) == "True";
             settings.MinifyKnockoutBindingExpressions = GetValue(bundle, "minifyKnockoutBindingExpressions") == "True";
+            settings.PreserveCase = GetValue(bundle, "preserveCase") == "True";
             settings.ProcessableScriptTypeList = GetValue(bundle, "processableScriptTypeList");
             settings.RemoveHtmlComments = GetValue(bundle, "removeHtmlComments", true) == "True";
             settings.RemoveTagsWithoutContent = GetValue(bundle, "removeTagsWithoutContent") == "True";

--- a/src/BundlerMinifier/packages.config
+++ b/src/BundlerMinifier/packages.config
@@ -5,5 +5,5 @@
   <package id="Minimatch" version="1.1.0.0" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
   <package id="NuGet.CommandLine" version="2.8.5" targetFramework="net45" />
-  <package id="WebMarkupMin.Core" version="1.0.0" targetFramework="net45" />
+  <package id="WebMarkupMin.Core" version="1.1.0" targetFramework="net45" />
 </packages>

--- a/src/BundlerMinifierVsix/JSON/bundleconfig-schema.json
+++ b/src/BundlerMinifierVsix/JSON/bundleconfig-schema.json
@@ -131,6 +131,11 @@
               "type": "boolean",
               "default": false
             },
+            "preserveCase": {
+              "description": "HTML only. Preserve case of tag and attribute names.",
+              "type": "boolean",
+              "default": false
+            },
             "processableScriptTypeList": {
               "description": "HTML only. Specify array of types of script tags, that are processed by minifier (e.g. [\"text/html\", \"text/ng-template\"]).",
               "type": "array"


### PR DESCRIPTION
This property allows to preserve case of tag and attribute names during HTML minification (useful for Angular 2 templates).