### PR TITLE
Add missing semicolon in gulp clean task

### DIFF
--- a/src/BundlerMinifierVsix/Resources/Files/gulpfile.js
+++ b/src/BundlerMinifierVsix/Resources/Files/gulpfile.js
@@ -43,7 +43,7 @@ gulp.task("min:html", function () {
 
 gulp.task("clean", function () {
     var files = bundleconfig.map(function (bundle) {
-        return bundle.outputFileName
+        return bundle.outputFileName;
     });
 
     return del(files);


### PR DESCRIPTION
There's a missing semicolon in the gulp `clean` task.