### PR TITLE
Make package.json consistent with item template

### DIFF
--- a/src/BundlerMinifierVsix/Resources/Files/package.json
+++ b/src/BundlerMinifierVsix/Resources/Files/package.json
@@ -1,4 +1,5 @@
 {
   "name": "app",
-  "version": "1.0.0"
+  "version": "1.0.0",
+  "private": true
 }


### PR DESCRIPTION
This PR explicitly defines the **private** property in `package.json` and sets it to `true`. This makes the `package.json` file consistent with the **npm Configuration File** item template.