### PR TITLE
Replace del with rimraf

### DIFF
--- a/src/BundlerMinifierVsix/Commands/ConvertToGulp.cs
+++ b/src/BundlerMinifierVsix/Commands/ConvertToGulp.cs
@@ -107,7 +107,7 @@ namespace BundlerMinifierVsix.Commands
             CreateFileAndIncludeInProject(project, gulpFile);
 
             BundlerMinifierPackage._dte.StatusBar.Text = "Installing node modules...";
-            InstallNodeModules(Dispatcher.CurrentDispatcher, root, "del", "gulp", "gulp-concat", "gulp-cssmin", "gulp-htmlmin", "gulp-uglify", "merge-stream");
+            InstallNodeModules(Dispatcher.CurrentDispatcher, root, "gulp", "gulp-concat", "gulp-cssmin", "gulp-htmlmin", "gulp-uglify", "merge-stream", "rimraf");
             BundleService.ToggleOutputProduction(project.GetConfigFile(), false);
         }
 

--- a/src/BundlerMinifierVsix/Resources/Files/gulpfile.js
+++ b/src/BundlerMinifierVsix/Resources/Files/gulpfile.js
@@ -6,7 +6,7 @@ var gulp = require("gulp"),
     htmlmin = require("gulp-htmlmin"),
     uglify = require("gulp-uglify"),
     merge = require("merge-stream"),
-    del = require("del"),
+    rimraf = require("rimraf"),
     bundleconfig = require("./bundleconfig.json"); // make sure bundleconfig.json doesn't contain any comments
 
 gulp.task("min", ["min:js", "min:css", "min:html"]);
@@ -41,12 +41,12 @@ gulp.task("min:html", function () {
     return merge(tasks);
 });
 
-gulp.task("clean", function () {
+gulp.task("clean", function (cb) {
     var files = bundleconfig.map(function (bundle) {
         return bundle.outputFileName;
     });
 
-    return del(files);
+    return rimraf(cb);
 });
 
 gulp.task("watch", function () {


### PR DESCRIPTION
This PR replaces `del` with `rimraf` as the npm file/folder deletion module, which reduces the npm packages footprint by a fair amount. Installing the `del` module results in a 528kb size on disk (or 109 files & 29 folders). Compare that to installing the `rimraf` module, which results in a 328kb size on disk (or 60 files & 15 folders). This module is also preferred since it was used through the RC2 release of ASP.NET Core's project templates. That development community is already somewhat familiar with `rimraf`.