### PR TITLE
Strip comments in bundleconfig.json during Gulp conversion

### DIFF
--- a/src/BundlerMinifierVsix/BundlerMinifierVsix.csproj
+++ b/src/BundlerMinifierVsix/BundlerMinifierVsix.csproj
@@ -116,7 +116,9 @@
     <Content Include="source.extension.ico">
       <DependentUpon>source.extension.vsixmanifest</DependentUpon>
     </Content>
-    <None Include="packages.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
     <Content Include="Resources\Files\package.json">
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
@@ -234,6 +236,10 @@
     </Reference>
     <Reference Include="Microsoft.VisualStudio.Utilities, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <Private>False</Private>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="NuGet.VisualStudio, Version=2.8.60318.667, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=x86">
       <HintPath>..\..\packages\NuGet.VisualStudio.2.8.5\lib\net40\NuGet.VisualStudio.dll</HintPath>

--- a/src/BundlerMinifierVsix/Commands/ConvertToGulp.cs
+++ b/src/BundlerMinifierVsix/Commands/ConvertToGulp.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.ComponentModel.Design;
 using System.Diagnostics;
 using System.IO;
@@ -10,6 +9,7 @@ using System.Windows;
 using System.Windows.Threading;
 using EnvDTE;
 using Microsoft.VisualStudio.Shell;
+using Newtonsoft.Json.Linq;
 
 namespace BundlerMinifierVsix.Commands
 {
@@ -212,11 +212,14 @@ namespace BundlerMinifierVsix.Commands
 
         private static void StripCommentsFromJsonFile(string fileName)
         {
-            IEnumerable<string> filteredFileContent = from line in File.ReadAllLines(fileName)
-                                                      where !line.TrimStart().StartsWith("//")
-                                                      select line;
+            string fileContent = File.ReadAllText(fileName);
+            var loadSettings = new JsonLoadSettings
+            {
+                CommentHandling = CommentHandling.Ignore
+            };
+            var filteredFileContent = JArray.Parse(fileContent, loadSettings);
 
-            File.WriteAllLines(fileName, filteredFileContent, Encoding.UTF8);
+            File.WriteAllText(fileName, filteredFileContent.ToString(), Encoding.UTF8);
         }
 
         private static void CreateFileAndIncludeInProject(Project project, string fileName)

--- a/src/BundlerMinifierVsix/Commands/ConvertToGulp.cs
+++ b/src/BundlerMinifierVsix/Commands/ConvertToGulp.cs
@@ -1,11 +1,11 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.ComponentModel.Design;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Text;
-using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Threading;
 using EnvDTE;
@@ -100,6 +100,10 @@ namespace BundlerMinifierVsix.Commands
 
             var project = ProjectHelpers.GetActiveProject();
             var root = project.GetRootFolder();
+
+            var bundleConfigFile = Path.Combine(root, Constants.CONFIG_FILENAME);
+            StripCommentsFromJsonFile(bundleConfigFile);
+
             var packageFile = Path.Combine(root, "package.json");
             var gulpFile = Path.Combine(root, "gulpfile.js");
 
@@ -166,10 +170,10 @@ namespace BundlerMinifierVsix.Commands
                 {
                     BundlerMinifierPackage._dte.StatusBar.Progress(false, "Node modules installed", 1, 1);
 
-                   if (!hasErrors)
-                       BundlerMinifierPackage._dte.StatusBar.Text = "Node modules installed";
-                   else
-                       BundlerMinifierPackage._dte.StatusBar.Text = "Error installing node modules. See output window for details";
+                    if (!hasErrors)
+                        BundlerMinifierPackage._dte.StatusBar.Text = "Node modules installed";
+                    else
+                        BundlerMinifierPackage._dte.StatusBar.Text = "Error installing node modules. See output window for details";
                 }), DispatcherPriority.ApplicationIdle, null);
             });
         }
@@ -204,6 +208,15 @@ namespace BundlerMinifierVsix.Commands
             }
 
             start.EnvironmentVariables["PATH"] = path;
+        }
+
+        private static void StripCommentsFromJsonFile(string fileName)
+        {
+            IEnumerable<string> filteredFileContent = from line in File.ReadAllLines(fileName)
+                                                      where !line.TrimStart().StartsWith("//")
+                                                      select line;
+
+            File.WriteAllLines(fileName, filteredFileContent, Encoding.UTF8);
         }
 
         private static void CreateFileAndIncludeInProject(Project project, string fileName)

--- a/src/BundlerMinifierVsix/Resources/Files/gulpfile.js
+++ b/src/BundlerMinifierVsix/Resources/Files/gulpfile.js
@@ -7,7 +7,7 @@ var gulp = require("gulp"),
     uglify = require("gulp-uglify"),
     merge = require("merge-stream"),
     del = require("del"),
-    bundleconfig = require("./bundleconfig.json"); // make sure bundleconfig.json doesn't contain any comments
+    bundleconfig = require("./bundleconfig.json");
 
 gulp.task("min", ["min:js", "min:css", "min:html"]);
 

--- a/src/BundlerMinifierVsix/packages.config
+++ b/src/BundlerMinifierVsix/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net46" />
   <package id="NuGet.VisualStudio" version="2.8.5" targetFramework="net451" />
 </packages>


### PR DESCRIPTION
This PR addresses issue #161 by stripping comments from the `bundleconfig.json` file before creating `gulpfile.js`. This eliminates the need to manually remove the comments.