### PR TITLE
Modify gulpfile.js and package.json file encoding types

### DIFF
--- a/src/BundlerMinifierVsix/Resources/Files/gulpfile.js
+++ b/src/BundlerMinifierVsix/Resources/Files/gulpfile.js
@@ -1,4 +1,4 @@
-"use strict";
+﻿"use strict";
 
 var gulp = require("gulp"),
     concat = require("gulp-concat"),

--- a/src/BundlerMinifierVsix/Resources/Files/package.json
+++ b/src/BundlerMinifierVsix/Resources/Files/package.json
@@ -1,4 +1,4 @@
-{
+﻿{
   "name": "app",
   "version": "1.0.0",
   "private": true


### PR DESCRIPTION
Change the encoding of `gulpfile.js` and `package.json` from **Western European (Windows)** to **Unicode (UTF-8) with signature**. This makes the files consistent with the encoding used in the VS "Gulp Configuration File" and "npm Configuration File" item templates.