### PR TITLE
Fix spelling mistake in resx file

### DIFF
--- a/src/BundlerMinifierVsix/Resources/Text.Designer.cs
+++ b/src/BundlerMinifierVsix/Resources/Text.Designer.cs
@@ -151,7 +151,7 @@ namespace BundlerMinifierVsix.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Unable to ininstall the {0} NuGet package.
+        ///   Looks up a localized string similar to Unable to uninstall the {0} NuGet package.
         /// </summary>
         internal static string NugetErrorUninstalling {
             get {

--- a/src/BundlerMinifierVsix/Resources/Text.resx
+++ b/src/BundlerMinifierVsix/Resources/Text.resx
@@ -179,7 +179,7 @@ Do you want to continue?</value>
     <value>Unable to install the {0} NuGet package</value>
   </data>
   <data name="NugetErrorUninstalling" xml:space="preserve">
-    <value>Unable to ininstall the {0} NuGet package</value>
+    <value>Unable to uninstall the {0} NuGet package</value>
   </data>
   <data name="NugetFinishedInstalling" xml:space="preserve">
     <value>Finished installing the {0} NuGet package</value>


### PR DESCRIPTION
Change "ininstall" to "uninstall" for the `NugetErrorUninstalling` value in `Text.resx`.