### PR TITLE
Fix for Issue #207

### DIFF
--- a/src/BundlerMinifier/BundlerMinifier.csproj
+++ b/src/BundlerMinifier/BundlerMinifier.csproj
@@ -80,7 +80,7 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>$(MSBuildProjectDirectory)\..\..\packages\NuGet.CommandLine.2.8.5\tools\nuget.exe pack .\msbuild\BuildBundlerMinifier.nuspec -Verbosity quiet</PostBuildEvent>
+    <PostBuildEvent>"$(MSBuildProjectDirectory)\..\..\packages\NuGet.CommandLine.2.8.5\tools\nuget.exe" pack .\msbuild\BuildBundlerMinifier.nuspec -Verbosity quiet</PostBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.


### PR DESCRIPTION
Quoted the build event path for Nuget.exe in the post build event for when MSBuildProjectDirectory contains spaces in the directory path