### PR TITLE
Include test3.json file in BundlerMinifierTest project

### DIFF
--- a/src/BundlerMinifierTest/BundlerMinifierTest.csproj
+++ b/src/BundlerMinifierTest/BundlerMinifierTest.csproj
@@ -68,6 +68,7 @@
     <None Include="artifacts\error.json" />
     <None Include="artifacts\test2.json" />
     <None Include="artifacts\test1.json" />
+    <None Include="artifacts\test3.json" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="artifacts\encoding.js" />


### PR DESCRIPTION
The `test3.json` file, used in the `JustGzip` unit test, wasn't included in the project. This PR explicitly includes the file in the project to make it clear that it's being used.