### PR TITLE
Remove old whitespaceMinificationMode property from test1.json

### DIFF
--- a/src/BundlerMinifierTest/artifacts/test1.json
+++ b/src/BundlerMinifierTest/artifacts/test1.json
@@ -30,8 +30,7 @@
       "file2.html"
     ],
     "minify": {
-      "enabled": true,
-      "whitespaceMinificationMode": "aggressive"
+      "enabled": true
     },
     "includeInProject": true
   },


### PR DESCRIPTION
The `test1.json` file's HTML minification section references a `whitespaceMinificationMode` property which no longer exists. 