### PR TITLE
Upgrade NUglify NuGet package to v1.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - [ ] Create additional source map for the bundle files
 - [ ] Adopt new VS Error List API
 - [x] Updated NuGet package to support .NET Core vNext
+- [x] Updated NUglify NuGet package to version 1.5.2 to address #135 & #63
 
 Features that have a checkmark are complete and available for
 download in the

--- a/src/BundlerMinifier.Core/project.json
+++ b/src/BundlerMinifier.Core/project.json
@@ -20,7 +20,7 @@
   },
 
   "dependencies": {
-    "NUglify": "1.5.1",
+    "NUglify": "1.5.2",
     "Newtonsoft.Json": "9.0.1"
   },
 

--- a/src/BundlerMinifier.Core/project.lock.json
+++ b/src/BundlerMinifier.Core/project.lock.json
@@ -3,7 +3,7 @@
   "version": 2,
   "targets": {
     ".NETCoreApp,Version=v1.0": {
-      "Libuv/1.9.0": {
+      "Libuv/1.9.1": {
         "type": "package",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.0.1"
@@ -122,7 +122,7 @@
       "Microsoft.NETCore.App/1.1.0": {
         "type": "package",
         "dependencies": {
-          "Libuv": "1.9.0",
+          "Libuv": "1.9.1",
           "Microsoft.CSharp": "4.0.1",
           "Microsoft.CodeAnalysis.CSharp": "1.3.0",
           "Microsoft.CodeAnalysis.VisualBasic": "1.3.0",
@@ -359,7 +359,7 @@
           "lib/netstandard1.0/Newtonsoft.Json.dll": {}
         }
       },
-      "NUglify/1.5.1": {
+      "NUglify/1.5.2": {
         "type": "package",
         "dependencies": {
           "NETStandard.Library": "1.6.0",
@@ -2098,7 +2098,7 @@
           "lib/net45/Newtonsoft.Json.dll": {}
         }
       },
-      "NUglify/1.5.1": {
+      "NUglify/1.5.2": {
         "type": "package",
         "frameworkAssemblies": [
           "System",
@@ -2116,12 +2116,12 @@
     }
   },
   "libraries": {
-    "Libuv/1.9.0": {
-      "sha512": "9Q7AaqtQhS8JDSIvRBt6ODSLWDBI4c8YxNxyCQemWebBFUtBbc6M5Vi5Gz1ZyIUlTW3rZK9bIr5gnVyv0z7a2Q==",
+    "Libuv/1.9.1": {
+      "sha512": "nC+mMOeCyXH2gPKBt0iVGtEnjTVJLl1aAOT85OQfZhbaufrXxEYiDEiRcGPevmuOPsMbMLOx0cpEpqJvlUrqSg==",
       "type": "package",
-      "path": "Libuv/1.9.0",
+      "path": "Libuv/1.9.1",
       "files": [
-        "Libuv.1.9.0.nupkg.sha512",
+        "Libuv.1.9.1.nupkg.sha512",
         "Libuv.nuspec",
         "License.txt",
         "runtimes/debian-x64/native/libuv.so",
@@ -2256,15 +2256,15 @@
       ]
     },
     "Microsoft.NETCore.App/1.1.0": {
-      "sha512": "qhjkElNOHvbaZHuQApI+6HMRtNFzY1cdAWLBq3IAi7xZ9U793xCc7xPK2ahkbRysxzdkc/dTC90VjWTtoBoxkg==",
+      "sha512": "8+e4SdKVw+gyeE4PJ2Ds7vsTBUDib6dNLvM172L31mF+XYS+Ug509PYilPnclrJA7r8Uy21MuczFl3VeZPAy2g==",
       "type": "package",
       "path": "Microsoft.NETCore.App/1.1.0",
       "files": [
+        "Microsoft.NETCore.App.1.1.0.nupkg.sha512",
+        "Microsoft.NETCore.App.nuspec",
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
-        "lib/netcoreapp1.0/_._",
-        "microsoft.netcore.app.1.1.0.nupkg.sha512",
-        "microsoft.netcore.app.nuspec"
+        "lib/netcoreapp1.0/_._"
       ]
     },
     "Microsoft.NETCore.DotNetHost/1.0.1": {
@@ -2506,12 +2506,12 @@
         "tools/install.ps1"
       ]
     },
-    "NUglify/1.5.1": {
-      "sha512": "iYV/OtSs+HgyE/RilY7UvGXYec6r0OJenWlPIdX/IivedVpSSdzxvPvUIyWpiV/6ad7VjantH0/6oaOhAZbaoQ==",
+    "NUglify/1.5.2": {
+      "sha512": "crRn4mozFho9iCrRMTbNqBPFRcuCV5rlIRBqkPA8Kz3qEBUVq53/W3PVhUeJQuEie6aDyXHMoNHymanQfJ45Ww==",
       "type": "package",
-      "path": "NUglify/1.5.1",
+      "path": "NUglify/1.5.2",
       "files": [
-        "NUglify.1.5.1.nupkg.sha512",
+        "NUglify.1.5.2.nupkg.sha512",
         "NUglify.nuspec",
         "lib/net35/NUglify.dll",
         "lib/net35/NUglify.xml",
@@ -6818,7 +6818,7 @@
   },
   "projectFileDependencyGroups": {
     "": [
-      "NUglify >= 1.5.1",
+      "NUglify >= 1.5.2",
       "Newtonsoft.Json >= 9.0.1"
     ],
     ".NETCoreApp,Version=v1.0": [

--- a/src/BundlerMinifier/BundlerMinifier.csproj
+++ b/src/BundlerMinifier/BundlerMinifier.csproj
@@ -46,8 +46,8 @@
       <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NUglify, Version=1.5.1.0, Culture=neutral, PublicKeyToken=15bc7810aec21b5e, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NUglify.1.5.1\lib\net40\NUglify.dll</HintPath>
+    <Reference Include="NUglify, Version=1.5.2.0, Culture=neutral, PublicKeyToken=15bc7810aec21b5e, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NUglify.1.5.2\lib\net40\NUglify.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/BundlerMinifier/packages.config
+++ b/src/BundlerMinifier/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
   <package id="NuGet.CommandLine" version="2.8.5" targetFramework="net45" />
-  <package id="NUglify" version="1.5.1" targetFramework="net45" />
+  <package id="NUglify" version="1.5.2" targetFramework="net45" />
 </packages>

--- a/src/BundlerMinifierTest/BundlerMinifierTest.csproj
+++ b/src/BundlerMinifierTest/BundlerMinifierTest.csproj
@@ -69,6 +69,8 @@
     <None Include="artifacts\test2.json" />
     <None Include="artifacts\test1.json" />
     <None Include="artifacts\test3.json" />
+    <None Include="artifacts\test4.json" />
+    <None Include="artifacts\test5.json" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="artifacts\encoding.js" />
@@ -81,6 +83,8 @@
     <Content Include="artifacts\file1.css" />
     <Content Include="artifacts\file2.js" />
     <Content Include="artifacts\file1.js" />
+    <Content Include="artifacts\file3.html" />
+    <Content Include="artifacts\file3.js" />
     <Content Include="artifacts\globbing\test.b.js" />
     <Content Include="artifacts\globbing\test.a.js" />
     <Content Include="artifacts\globbing\a.js" />

--- a/src/BundlerMinifierTest/BundlerTest.cs
+++ b/src/BundlerMinifierTest/BundlerTest.cs
@@ -36,6 +36,8 @@ namespace BundlerMinifierTest
             File.Delete("../../artifacts/minify.min.js.gz");
             File.Delete("../../artifacts/encoding/encoding.js");
             File.Delete("../../artifacts/encoding/encoding.min.js");
+            File.Delete("../../artifacts/file3.min.html");
+            File.Delete("../../artifacts/file3.min.js");
         }
 
         [TestMethod]
@@ -151,6 +153,24 @@ namespace BundlerMinifierTest
 
             bool result = File.Exists("../../artifacts/error.min.css");
             Assert.IsFalse(result);
+        }
+
+        [TestMethod]
+        public void PreserveKnockoutContainerlessBindings()
+        {
+            _processor.Process(TEST_BUNDLE.Replace("test1", "test4"));
+
+            string htmlResult = File.ReadAllText("../../artifacts/file3.min.html");
+            Assert.AreEqual("<div><!--ko if:observable--><p></p><!--/ko--></div>", htmlResult);
+        }
+
+        [TestMethod]
+        public void PreserveJavaScript0EvalStatements()
+        {
+            _processor.Process(TEST_BUNDLE.Replace("test1", "test5"));
+
+            string jsResult = File.ReadAllText("../../artifacts/file3.min.js");
+            Assert.AreEqual("(function(n){n()})(function(){\"use strict\";var n=(0,eval)(\"this\");console.log(n)});", jsResult);
         }
     }
 }

--- a/src/BundlerMinifierTest/artifacts/file3.html
+++ b/src/BundlerMinifierTest/artifacts/file3.html
@@ -1,0 +1,6 @@
+﻿<!-- This is a test HTML comment -->
+<div>
+    <!--ko if:observable-->
+    <p></p>
+    <!--/ko-->
+</div>

--- a/src/BundlerMinifierTest/artifacts/file3.js
+++ b/src/BundlerMinifierTest/artifacts/file3.js
@@ -1,0 +1,8 @@
+﻿(function (factory) {
+    factory();
+}
+(function () {
+    "use strict";
+    var global = (0, eval)('this');
+    console.log(global); // Is undefined when run from the minified file
+}));

--- a/src/BundlerMinifierTest/artifacts/test4.json
+++ b/src/BundlerMinifierTest/artifacts/test4.json
@@ -1,0 +1,12 @@
+﻿[
+  {
+    "outputFileName": "file3.min.html",
+    "inputFiles": [
+      "file3.html"
+    ],
+    "minify": {
+      "enabled": true,
+      "removeHtmlComments": true
+    }
+  }
+]

--- a/src/BundlerMinifierTest/artifacts/test5.json
+++ b/src/BundlerMinifierTest/artifacts/test5.json
@@ -1,0 +1,11 @@
+﻿[
+  {
+    "outputFileName": "file3.min.js",
+    "inputFiles": [
+      "file3.js"
+    ],
+    "minify": {
+      "enabled": true
+    }
+  }
+]


### PR DESCRIPTION
Upgrade the [NUglify](https://www.nuget.org/packages/NUglify/) NuGet package from version 1.5.1 to version 1.5.2 to address issues https://github.com/madskristensen/BundlerMinifier/issues/135 and https://github.com/madskristensen/BundlerMinifier/issues/63. Also added a couple unit tests specifically for the 2 aforementioned issues.