### PR TITLE
Add support for NUglify property KeepOneSpaceWhenCollapsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 - [ ] Create additional source map for the bundle files
 - [ ] Adopt new VS Error List API
 - [x] Updated NuGet package to support .NET Core vNext
-- [x] Updated NUglify NuGet package to version 1.5.2 to address #135 & #63
+- [x] Added support to preserve Knockout containerless bindings and (0, eval) JavaScript expressions (#135 & #63)
+- [x] Added "KeepOneSpaceWhenCollapsing" to HTML options (#199)
 
 Features that have a checkmark are complete and available for
 download in the

--- a/src/BundlerMinifier.Core/Minify/HtmlOptions.cs
+++ b/src/BundlerMinifier.Core/Minify/HtmlOptions.cs
@@ -18,7 +18,8 @@ namespace BundlerMinifier
                 RemoveComments = GetValue(bundle, "removeHtmlComments", true) == "True",
                 RemoveQuotedAttributes = GetValue(bundle, "removeQuotedAttributes", true) == "True",
                 CollapseWhitespaces = GetValue(bundle, "collapseWhitespace", true) == "True",
-                IsFragmentOnly = GetValue(bundle, "isFragmentOnly", true) == "True"
+                IsFragmentOnly = GetValue(bundle, "isFragmentOnly", true) == "True",
+                KeepOneSpaceWhenCollapsing = GetValue(bundle, "keepOneSpaceWhenCollapsing", false) == "True"
             };
 
             return settings;

--- a/src/BundlerMinifier.Core/project.json
+++ b/src/BundlerMinifier.Core/project.json
@@ -20,7 +20,7 @@
   },
 
   "dependencies": {
-    "NUglify": "1.5.2",
+    "NUglify": "1.5.4",
     "Newtonsoft.Json": "9.0.1"
   },
 

--- a/src/BundlerMinifier.Core/project.lock.json
+++ b/src/BundlerMinifier.Core/project.lock.json
@@ -359,7 +359,7 @@
           "lib/netstandard1.0/Newtonsoft.Json.dll": {}
         }
       },
-      "NUglify/1.5.2": {
+      "NUglify/1.5.4": {
         "type": "package",
         "dependencies": {
           "NETStandard.Library": "1.6.0",
@@ -2098,7 +2098,7 @@
           "lib/net45/Newtonsoft.Json.dll": {}
         }
       },
-      "NUglify/1.5.2": {
+      "NUglify/1.5.4": {
         "type": "package",
         "frameworkAssemblies": [
           "System",
@@ -2506,12 +2506,12 @@
         "tools/install.ps1"
       ]
     },
-    "NUglify/1.5.2": {
-      "sha512": "crRn4mozFho9iCrRMTbNqBPFRcuCV5rlIRBqkPA8Kz3qEBUVq53/W3PVhUeJQuEie6aDyXHMoNHymanQfJ45Ww==",
+    "NUglify/1.5.4": {
+      "sha512": "MxYC4UDAjkGf2Zn5hpLqy163DQ36OAhOpoqe8r29KvY/MJ6N8Wdeee+D0XiutGzCF65DcFKjlEhRtmtw8pe2gQ==",
       "type": "package",
-      "path": "NUglify/1.5.2",
+      "path": "NUglify/1.5.4",
       "files": [
-        "NUglify.1.5.2.nupkg.sha512",
+        "NUglify.1.5.4.nupkg.sha512",
         "NUglify.nuspec",
         "lib/net35/NUglify.dll",
         "lib/net35/NUglify.xml",
@@ -6818,7 +6818,7 @@
   },
   "projectFileDependencyGroups": {
     "": [
-      "NUglify >= 1.5.2",
+      "NUglify >= 1.5.4",
       "Newtonsoft.Json >= 9.0.1"
     ],
     ".NETCoreApp,Version=v1.0": [

--- a/src/BundlerMinifier/BundlerMinifier.csproj
+++ b/src/BundlerMinifier/BundlerMinifier.csproj
@@ -46,8 +46,8 @@
       <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NUglify, Version=1.5.2.0, Culture=neutral, PublicKeyToken=15bc7810aec21b5e, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NUglify.1.5.2\lib\net40\NUglify.dll</HintPath>
+    <Reference Include="NUglify, Version=1.5.4.0, Culture=neutral, PublicKeyToken=15bc7810aec21b5e, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NUglify.1.5.4\lib\net40\NUglify.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/BundlerMinifier/packages.config
+++ b/src/BundlerMinifier/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
   <package id="NuGet.CommandLine" version="2.8.5" targetFramework="net45" />
-  <package id="NUglify" version="1.5.2" targetFramework="net45" />
+  <package id="NUglify" version="1.5.4" targetFramework="net45" />
 </packages>

--- a/src/BundlerMinifierTest/BundlerMinifierTest.csproj
+++ b/src/BundlerMinifierTest/BundlerMinifierTest.csproj
@@ -71,6 +71,7 @@
     <None Include="artifacts\test3.json" />
     <None Include="artifacts\test4.json" />
     <None Include="artifacts\test5.json" />
+    <None Include="artifacts\test6.json" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="artifacts\encoding.js" />
@@ -85,6 +86,7 @@
     <Content Include="artifacts\file1.js" />
     <Content Include="artifacts\file3.html" />
     <Content Include="artifacts\file3.js" />
+    <Content Include="artifacts\file4.html" />
     <Content Include="artifacts\globbing\test.b.js" />
     <Content Include="artifacts\globbing\test.a.js" />
     <Content Include="artifacts\globbing\a.js" />

--- a/src/BundlerMinifierTest/BundlerTest.cs
+++ b/src/BundlerMinifierTest/BundlerTest.cs
@@ -38,6 +38,7 @@ namespace BundlerMinifierTest
             File.Delete("../../artifacts/encoding/encoding.min.js");
             File.Delete("../../artifacts/file3.min.html");
             File.Delete("../../artifacts/file3.min.js");
+            File.Delete("../../artifacts/file4.min.html");
         }
 
         [TestMethod]
@@ -171,6 +172,15 @@ namespace BundlerMinifierTest
 
             string jsResult = File.ReadAllText("../../artifacts/file3.min.js");
             Assert.AreEqual("(function(n){n()})(function(){\"use strict\";var n=(0,eval)(\"this\");console.log(n)});", jsResult);
+        }
+
+        [TestMethod]
+        public void KeepOneSpaceWhenCollapsingHtml()
+        {
+            _processor.Process(TEST_BUNDLE.Replace("test1", "test6"));
+
+            string htmlResult = File.ReadAllText("../../artifacts/file4.min.html");
+            Assert.AreEqual("<div class=\"bold\"><span><i class=\"fa fa-phone\"></i></span> <span>DEF</span></div>", htmlResult);
         }
     }
 }

--- a/src/BundlerMinifierTest/artifacts/file4.html
+++ b/src/BundlerMinifierTest/artifacts/file4.html
@@ -1,0 +1,3 @@
+﻿<div class="bold">
+    <span><i class="fa fa-phone"></i></span> <span>DEF</span>
+</div>

--- a/src/BundlerMinifierTest/artifacts/test6.json
+++ b/src/BundlerMinifierTest/artifacts/test6.json
@@ -1,0 +1,13 @@
+﻿[
+  {
+    "outputFileName": "file4.min.html",
+    "inputFiles": [
+      "file4.html"
+    ],
+    "minify": {
+      "enabled": true,
+      "keepOneSpaceWhenCollapsing": true,
+      "removeQuotedAttributes": false
+    }
+  }
+]


### PR DESCRIPTION
Address issue #199 by upgrading to the NUglify v1.5.4 NuGet package. This gives us support for the `KeepOneSpaceWhenCollapsing` property when doing HTML minification.