### PR TITLE
No files matched the pattern even if there are matched files

### DIFF
--- a/src/BundlerMinifier.Core/Bundle/Bundle.cs
+++ b/src/BundlerMinifier.Core/Bundle/Bundle.cs
@@ -99,7 +99,7 @@ namespace BundlerMinifier
                     var matches = Minimatcher.Filter(allFiles, inputFile, options).Select(f => Path.Combine(folder, f));
                     matches = matches.Where(match => match != output && match != outputMin).ToList();
 
-                    if (notifyOnPatternMiss)
+                    if (notifyOnPatternMiss && !matches.Any())
                     {
                         Console.WriteLine($"  No files matched the pattern {inputFile}".Orange().Bright());
                     }


### PR DESCRIPTION
Fixed console message that should be shown only if there is a setting and there are no files by pattern.