### PR TITLE
In CSS and JavaScript options added `ignorableErrors` property

### DIFF
--- a/src/BundlerMinifier.Core/Minify/CssOptions.cs
+++ b/src/BundlerMinifier.Core/Minify/CssOptions.cs
@@ -8,6 +8,7 @@ namespace BundlerMinifier
         public static CssSettings GetSettings(Bundle bundle)
         {
             CssSettings settings = new CssSettings();
+            settings.IgnoreErrorList = GetValue(bundle, "ignorableErrors", string.Empty);
             settings.TermSemicolons = GetValue(bundle, "termSemicolons") == "True";
 
             string cssComment = GetValue(bundle, "commentMode");

--- a/src/BundlerMinifier.Core/Minify/JavaScriptOptions.cs
+++ b/src/BundlerMinifier.Core/Minify/JavaScriptOptions.cs
@@ -9,7 +9,7 @@ namespace BundlerMinifier
         {
             CodeSettings settings = new CodeSettings();
             settings.AlwaysEscapeNonAscii = GetValue(bundle, "alwaysEscapeNonAscii", false) == "True";
-
+            settings.IgnoreErrorList = GetValue(bundle, "ignorableErrors", string.Empty);
             settings.PreserveImportantComments = GetValue(bundle, "preserveImportantComments", true) == "True";
             settings.TermSemicolons = GetValue(bundle, "termSemicolons", true) == "True";
 


### PR DESCRIPTION
Sometimes it is necessary to ignore some errors (for example, `JS1019,JS1300`).