### PR TITLE
added automatic feature to handle *.debug.js files on  bundle and …

### DIFF
--- a/src/BundlerMinifier.Core/Bundle/Bundle.cs
+++ b/src/BundlerMinifier.Core/Bundle/Bundle.cs
@@ -49,6 +49,15 @@ namespace BundlerMinifier
         }
 
         [JsonIgnore]
+        public bool IsDebugMinificationEnabled
+        {
+            get
+            {
+                return IsMinificationEnabled && InputFiles.Count == 1 && InputFiles[0].EndsWith(".debug.js");
+            }
+        }
+
+        [JsonIgnore]
         public bool OutputIsMinFile
         {
             get { return Path.GetFileName(OutputFileName).Contains(".min."); }

--- a/src/BundlerMinifier.Core/Bundle/BundleFileProcessor.cs
+++ b/src/BundlerMinifier.Core/Bundle/BundleFileProcessor.cs
@@ -124,7 +124,7 @@ namespace BundlerMinifier
                 }
             }
 
-            string minFile = BundleMinifier.GetMinFileName(bundle.GetAbsoluteOutputFile());
+            string minFile = BundleMinifier.GetMinFileName(bundle.GetAbsoluteOutputFile(), bundle.IsDebugMinificationEnabled);
 
             if (bundle.IsMinificationEnabled || bundle.IsGzipEnabled)
             {
@@ -164,7 +164,7 @@ namespace BundlerMinifier
                 }
             }
 
-            string minFile = BundleMinifier.GetMinFileName(bundle.GetAbsoluteOutputFile());
+            string minFile = BundleMinifier.GetMinFileName(bundle.GetAbsoluteOutputFile(), bundle.IsDebugMinificationEnabled);
             string mapFile = minFile + ".map";
             string gzFile = minFile + ".gz";
 

--- a/src/BundlerMinifier.Core/Minify/BundleMinifier.cs
+++ b/src/BundlerMinifier.Core/Minify/BundleMinifier.cs
@@ -46,7 +46,9 @@ namespace BundlerMinifier
             }
             else if (bundle.IsGzipEnabled)
             {
-                string minFile = bundle.IsMinificationEnabled ? GetMinFileName(bundle.GetAbsoluteOutputFile()) : bundle.GetAbsoluteOutputFile();
+                string minFile = bundle.IsMinificationEnabled 
+                    ? GetMinFileName(bundle.GetAbsoluteOutputFile(), bundle.IsDebugMinificationEnabled) 
+                    : bundle.GetAbsoluteOutputFile();
                 GzipFile(minFile, bundle, minResult);
             }
 
@@ -65,7 +67,7 @@ namespace BundlerMinifier
             }
             else
             {
-                string minFile = GetMinFileName(minResult.FileName);
+                string minFile = GetMinFileName(minResult.FileName, bundle.IsDebugMinificationEnabled);
                 string mapFile = minFile + ".map";
 
                 using (StringWriter writer = new StringWriter())
@@ -113,7 +115,8 @@ namespace BundlerMinifier
 
         private static void WriteMinFile(Bundle bundle, MinificationResult minResult, UgliflyResult uglifyResult)
         {
-            var minFile = GetMinFileName(minResult.FileName);
+            var minFile = GetMinFileName(minResult.FileName, bundle.IsDebugMinificationEnabled);
+
             minResult.MinifiedContent = uglifyResult.Code?.Trim();
 
             if (!uglifyResult.HasErrors)
@@ -183,7 +186,7 @@ namespace BundlerMinifier
             });
         }
 
-        public static string GetMinFileName(string file)
+        public static string GetMinFileName(string file, bool? isDebugMinificationEnabled = false)
         {
             string fileName = Path.GetFileName(file);
 
@@ -191,9 +194,20 @@ namespace BundlerMinifier
                 return file;
 
             string ext = Path.GetExtension(file);
-            return file.Substring(0, file.LastIndexOf(ext, StringComparison.OrdinalIgnoreCase)) + ".min" + ext;
+
+            fileName = file.EndsWith(".debug.js")
+                ? file.Replace(".debug.", ".")
+                : file.Substring(0, file.LastIndexOf(ext, StringComparison.OrdinalIgnoreCase)) + ".min" + ext;
+
+            if (isDebugMinificationEnabled != null && isDebugMinificationEnabled == true && fileName.Contains(".min."))
+            {
+                fileName = fileName.Replace(".min.", ".");
+            }
+
+            return fileName;
         }
 
+        
         static void OnBeforeWritingMinFile(string file, string minFile, Bundle bundle, bool containsChanges)
         {
             BeforeWritingMinFile?.Invoke(null, new MinifyFileEventArgs(file, minFile, bundle, containsChanges));

--- a/src/BundlerMinifier/MSBuild/BundlerCleanTask.cs
+++ b/src/BundlerMinifier/MSBuild/BundlerCleanTask.cs
@@ -30,7 +30,7 @@ namespace BundlerMinifier
                     var outputFile = bundle.GetAbsoluteOutputFile();
                     var inputFiles = bundle.GetAbsoluteInputFiles();
 
-                    var minFile = BundleMinifier.GetMinFileName(outputFile);
+                    var minFile = BundleMinifier.GetMinFileName(outputFile, bundle.IsDebugMinificationEnabled);
                     var mapFile = minFile + ".map";
                     var gzipFile = minFile + ".gz";
 

--- a/src/BundlerMinifierTest/BundlerMinifierTest.csproj
+++ b/src/BundlerMinifierTest/BundlerMinifierTest.csproj
@@ -6,6 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\BundlerMinifierVsix\BundlerMinifierVsix.csproj" />
     <ProjectReference Include="..\BundlerMinifier\BundlerMinifier.csproj" />
   </ItemGroup>
 

--- a/src/BundlerMinifierTest/artifacts/file5.debug.js
+++ b/src/BundlerMinifierTest/artifacts/file5.debug.js
@@ -1,0 +1,3 @@
+﻿var file1 = 1;
+var file2 = file1;
+var sumFromFiles = file1 + file2;

--- a/src/BundlerMinifierTest/artifacts/test1.json
+++ b/src/BundlerMinifierTest/artifacts/test1.json
@@ -1,28 +1,36 @@
 ﻿[
-	{
-		"outputFileName": "foo.js",
-		"inputFiles": [
-			"file1.js",
-			"file2.js"
-		],
-		"minify": {
-			"enabled": true
-		},
-		"includeInProject": true,
-		"sourceMap": true
-	},
-	{
-		"outputFileName": "foo.css",
-		"inputFiles": [
-			"file1.css",
+  {
+    "outputFileName": "foo.js",
+    "inputFiles": [
+      "file1.js",
+      "file2.js"
+    ],
+    "minify": {
+      "enabled": true
+    },
+    "includeInProject": true,
+    "sourceMap": true
+  },
+  {
+    "outputFileName": "bundle.debug.js",
+    "inputFiles": [
+      "file1.js",
+      "file2.js"
+    ],
+    "includeInProject": true
+  },
+  {
+    "outputFileName": "foo.css",
+    "inputFiles": [
+      "file1.css",
       "file2.css",
       "test2/foo.css"
-		],
-		"minify": {
+    ],
+    "minify": {
       "enabled": true
-		},
-		"includeInProject": true
-	},
+    },
+    "includeInProject": true
+  },
   {
     "outputFileName": "foo.html",
     "inputFiles": [

--- a/src/BundlerMinifierVsix/BundleService.cs
+++ b/src/BundlerMinifierVsix/BundleService.cs
@@ -40,6 +40,13 @@ namespace BundlerMinifierVsix
                     if (File.Exists(unMinFile))
                         sourceFile = unMinFile;
                 }
+                else if (e.Bundle.IsDebugMinificationEnabled)
+                {
+                    string ext = Path.GetExtension(sourceFile);
+                    var unMinFile = sourceFile.Replace(ext, ".debug" + ext);
+                    if (File.Exists(unMinFile))
+                        sourceFile = unMinFile;
+                }
 
                 // Bundle file minification
                 if (e.Bundle.IncludeInProject)

--- a/src/BundlerMinifierVsix/Helpers/FileHelpers.cs
+++ b/src/BundlerMinifierVsix/Helpers/FileHelpers.cs
@@ -1,5 +1,5 @@
-﻿using System.IO;
-using BundlerMinifier;
+﻿using System;
+using System.IO;
 
 namespace BundlerMinifierVsix
 {
@@ -15,7 +15,10 @@ namespace BundlerMinifierVsix
         public static string GetMinFileName(string file)
         {
             string ext = Path.GetExtension(file);
-            return file.Substring(0, file.LastIndexOf(ext)) + ".min" + ext;
+
+            return file.EndsWith(".debug.js")
+                ? file.Replace(".debug.", ".")
+                : file.Substring(0, file.LastIndexOf(ext, StringComparison.OrdinalIgnoreCase)) + ".min" + ext;
         }
 
         public static bool HasSourceMap(string file, out string sourceMap)


### PR DESCRIPTION
…minify to *.js able to use in projects for SharePoint (linked are the *.js files, if SP is in debug mode, the *.debug.js version are automatically delivered)

I have change this PR, so it works now like the minifier and bundling on on JS files. 
Means if you select one foo.debug.js file, minification produces a foo.js and add them to the project.
If you select more then one file and the bundler output name is constructed like foo.debug.js, foo.js is produced  as min file.

In SharePoint (SP)  projects where the JS is hosted on SP, it's very helpful if you are able to use the std. debug functionality of the farm. If something went wrong, you have ideally a front-end server for yourself, switched on web.config to debug mode, and now the client browser gets all JS files with content from debug files. And i think most dev boxes are running in debug mode ;)
 
assoc with Issue #276