### PR TITLE
BundleMinify runs after TypeScript is compiled

### DIFF
--- a/src/BundlerMinifier/build/BuildBundlerMinifier.targets
+++ b/src/BundlerMinifier/build/BuildBundlerMinifier.targets
@@ -1,12 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-
   <PropertyGroup>
-    <BuildDependsOn>
-        BundleMinify;
-        $(BuildDependsOn)
-    </BuildDependsOn>
-
     <_BundlerMinifierTaskAssembly Condition="'$(MSBuildRuntimeType)' == 'Core'">..\tools\netstandard1.3\BundlerMinifier.dll</_BundlerMinifierTaskAssembly>
     <_BundlerMinifierTaskAssembly Condition="'$(MSBuildRuntimeType)' != 'Core'">..\tools\net46\BundlerMinifier.dll</_BundlerMinifierTaskAssembly>
   </PropertyGroup>
@@ -14,12 +8,11 @@
   <UsingTask AssemblyFile="$(_BundlerMinifierTaskAssembly)" TaskName="BundlerMinifier.BundlerBuildTask"/>
   <UsingTask AssemblyFile="$(_BundlerMinifierTaskAssembly)" TaskName="BundlerMinifier.BundlerCleanTask"/>
 
-  <Target Name="BundleMinify" Condition="'$(RunBundleMinify)' != 'False'">
+  <Target Name="BundleMinify" AfterTargets="CompileTypeScriptWithTSConfig" BeforeTargets="BeforeCompile" Condition="'$(RunBundleMinify)' != 'False'">
     <BundlerMinifier.BundlerBuildTask FileName="$(MSBuildProjectDirectory)\bundleconfig.json" />
   </Target>
 
   <Target Name="BundleMinifyClean" AfterTargets="CoreClean" Condition="'$(RunBundleMinify)' != 'False'">
     <BundlerMinifier.BundlerCleanTask FileName="$(MSBuildProjectDirectory)\bundleconfig.json" />
   </Target>
-
 </Project>


### PR DESCRIPTION
I have updated the `BuildMinify` target to run after the TypeScript compilation is finished. It has no effect if TypeScript is not used in the project. I have also tested compatibility with WebCompiler. Didn't find any issues.

This PR replaces the https://github.com/madskristensen/BundlerMinifier/pull/168 pull request.