### PR TITLE
Extract bundleconfig.json location from targets into a variable

### DIFF
--- a/src/BundlerMinifier/build/BuildBundlerMinifier.targets
+++ b/src/BundlerMinifier/build/BuildBundlerMinifier.targets
@@ -3,16 +3,17 @@
   <PropertyGroup>
     <_BundlerMinifierTaskAssembly Condition="'$(MSBuildRuntimeType)' == 'Core'">..\tools\netstandard1.3\BundlerMinifier.dll</_BundlerMinifierTaskAssembly>
     <_BundlerMinifierTaskAssembly Condition="'$(MSBuildRuntimeType)' != 'Core'">..\tools\net46\BundlerMinifier.dll</_BundlerMinifierTaskAssembly>
+    <BundleConfig Condition="'$(BundleConfig)' == ''">$(MSBuildProjectDirectory)\bundleconfig.json</BundleConfig>
   </PropertyGroup>
 
   <UsingTask AssemblyFile="$(_BundlerMinifierTaskAssembly)" TaskName="BundlerMinifier.BundlerBuildTask"/>
   <UsingTask AssemblyFile="$(_BundlerMinifierTaskAssembly)" TaskName="BundlerMinifier.BundlerCleanTask"/>
 
   <Target Name="BundleMinify" AfterTargets="CompileTypeScriptWithTSConfig" BeforeTargets="BeforeCompile" Condition="'$(RunBundleMinify)' != 'False'">
-    <BundlerMinifier.BundlerBuildTask FileName="$(MSBuildProjectDirectory)\bundleconfig.json" />
+    <BundlerMinifier.BundlerBuildTask FileName="$(BundleConfig)" />
   </Target>
 
   <Target Name="BundleMinifyClean" AfterTargets="CoreClean" Condition="'$(RunBundleMinify)' != 'False'">
-    <BundlerMinifier.BundlerCleanTask FileName="$(MSBuildProjectDirectory)\bundleconfig.json" />
+    <BundlerMinifier.BundlerCleanTask FileName="$(BundleConfig)" />
   </Target>
 </Project>


### PR DESCRIPTION
Extract `bundleconfig.json` file location path from `BundleMinify` and `BundleMinifyClean` targets into the `BundleConfig` variable to allow specifying the location in a particular project file, also resolves #278.