### PR TITLE
Create directory if it does not exist

### DIFF
--- a/src/BundlerMinifier.Core/Minify/BundleMinifier.cs
+++ b/src/BundlerMinifier.Core/Minify/BundleMinifier.cs
@@ -124,6 +124,7 @@ namespace BundlerMinifier
 
                 if (containsChanges)
                 {
+                    Directory.CreateDirectory(Path.GetDirectoryName(minFile));
                     File.WriteAllText(minFile, minResult.MinifiedContent, new UTF8Encoding(false));
                     OnAfterWritingMinFile(minResult.FileName, minFile, bundle, containsChanges);
                 }


### PR DESCRIPTION
Minification fails if the target directory does not exist. This fix will create the directory before writing the file. Note `Directory.CreateDirectory` does nothing if the directory already exists.