### PR TITLE
Issue: #351.

### DIFF
--- a/src/BundlerMinifierVsix/Commands/ProjectEventCommand.cs
+++ b/src/BundlerMinifierVsix/Commands/ProjectEventCommand.cs
@@ -33,6 +33,10 @@ namespace BundlerMinifierVsix.Commands
             _events.ProjectRemoved += OnProjectRemoved;
 
             _timer = new Timer(TimerElapsed, null, 0, 250);
+            if (dte.Solution.IsOpen)
+            {
+                OnSolutionOpened();
+            }
         }
 
         public static ProjectEventCommand Instance { get; private set; }


### PR DESCRIPTION
Because now package is async, it may be loaded after solution is already opened. If solution is opened, we just manually call method from it event.