### PR TITLE
WIP: Add TagHelper

### DIFF
--- a/BundlerMinifier.sln
+++ b/BundlerMinifier.sln
@@ -19,6 +19,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BundlerMinifier.Core", "src
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BundlerMinifierConsole", "src\BundlerMinifierConsole\BundlerMinifierConsole.csproj", "{005A7A66-2F08-4A2C-9230-F4FA31A6804B}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BundlerMinifier.TagHelpers", "src\BundlerMinifier.TagHelpers\BundlerMinifier.TagHelpers.csproj", "{2825CF4A-3F4C-4DC6-AEBB-09E71474D844}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -45,8 +47,15 @@ Global
 		{005A7A66-2F08-4A2C-9230-F4FA31A6804B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{005A7A66-2F08-4A2C-9230-F4FA31A6804B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{005A7A66-2F08-4A2C-9230-F4FA31A6804B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2825CF4A-3F4C-4DC6-AEBB-09E71474D844}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2825CF4A-3F4C-4DC6-AEBB-09E71474D844}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2825CF4A-3F4C-4DC6-AEBB-09E71474D844}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2825CF4A-3F4C-4DC6-AEBB-09E71474D844}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {1A316AB0-D62D-4181-8CB6-891E27E95782}
 	EndGlobalSection
 EndGlobal

--- a/src/BundlerMinifier.Core/BundlerMinifier.Core.csproj
+++ b/src/BundlerMinifier.Core/BundlerMinifier.Core.csproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <Version>1.0.0</Version>
-    <TargetFrameworks>netcoreapp1.0;net452;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp1.0;net452;netcoreapp2.0;netstandard2.0</TargetFrameworks>
     <DefineConstants>$(DefineConstants);DOTNET</DefineConstants>
     <AssemblyName>dotnet-bundle</AssemblyName>
     <OutputType>Exe</OutputType>

--- a/src/BundlerMinifier.TagHelpers/Bundle.cs
+++ b/src/BundlerMinifier.TagHelpers/Bundle.cs
@@ -1,0 +1,11 @@
+﻿using System.Collections.Generic;
+
+namespace BundlerMinifier.TagHelpers
+{
+    public class Bundle
+    {
+        public string Name { get; set; }
+        public string OutputFileUrl { get; set; }
+        public IList<string> InputFileUrls { get; set; }
+    }
+}

--- a/src/BundlerMinifier.TagHelpers/BundleExtensions.cs
+++ b/src/BundlerMinifier.TagHelpers/BundleExtensions.cs
@@ -1,0 +1,31 @@
+using System;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace BundlerMinifier.TagHelpers
+{
+    public static class BundleExtensions
+    {
+        public static IServiceCollection AddBundles(this IServiceCollection services)
+        {
+            return AddBundles(services, null);
+        }
+
+        public static IServiceCollection AddBundles(this IServiceCollection services, Action<BundleOptions> configure)
+        {
+            services.AddSingleton<IBundleProvider, BundleProvider>();
+            services.AddTransient<BundleOptions>(serviceProvider =>
+            {
+                var env = serviceProvider.GetService<IHostingEnvironment>();
+
+                var options = new BundleOptions();
+                options.Configure(env);
+                configure?.Invoke(options);
+
+                return options;
+            });
+
+            return services;
+        }
+    }
+}

--- a/src/BundlerMinifier.TagHelpers/BundleOptions.cs
+++ b/src/BundlerMinifier.TagHelpers/BundleOptions.cs
@@ -1,0 +1,22 @@
+using Microsoft.AspNetCore.Hosting;
+
+namespace BundlerMinifier.TagHelpers
+{
+    public class BundleOptions
+    {
+        public bool UseBundles { get; set; }
+        public bool UseMinifiedFiles { get; set; }
+        public bool AppendVersion { get; set; }        
+
+        internal void Configure(IHostingEnvironment env)
+        {
+            if (env != null)
+            {
+                var isDevelopment = env.IsDevelopment();
+                UseBundles = !isDevelopment;
+                UseMinifiedFiles = !isDevelopment;
+                AppendVersion = !isDevelopment;
+            }
+        }
+    }
+}

--- a/src/BundlerMinifier.TagHelpers/BundleTagHelper.cs
+++ b/src/BundlerMinifier.TagHelpers/BundleTagHelper.cs
@@ -1,0 +1,142 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Encodings.Web;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Html;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using Microsoft.AspNetCore.Mvc.Routing;
+using Microsoft.AspNetCore.Mvc.TagHelpers.Internal;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using Microsoft.AspNetCore.Razor.TagHelpers;
+using Microsoft.Extensions.Caching.Memory;
+
+namespace BundlerMinifier.TagHelpers
+{
+    [HtmlTargetElement("bundle")]
+    public class BundleTagHelper : TagHelper
+    {
+        private readonly IBundleProvider _bundleProvider;
+        private readonly BundleOptions _options;
+        private readonly IHostingEnvironment _hostingEnvironment;
+        private readonly IMemoryCache _cache;
+        private readonly HtmlEncoder _htmlEncoder;
+        private readonly IUrlHelperFactory _urlHelperFactory;
+        private FileVersionProvider _fileVersionProvider;
+
+        public BundleTagHelper(IHostingEnvironment hostingEnvironment, IMemoryCache cache, HtmlEncoder htmlEncoder, IUrlHelperFactory urlHelperFactory, BundleOptions options = null, IBundleProvider bundleProvider = null)
+        {
+            if (hostingEnvironment == null) throw new ArgumentNullException(nameof(hostingEnvironment));
+            if (cache == null) throw new ArgumentNullException(nameof(cache));
+            if (htmlEncoder == null) throw new ArgumentNullException(nameof(htmlEncoder));
+            if (urlHelperFactory == null) throw new ArgumentNullException(nameof(urlHelperFactory));
+
+            if (options == null)
+            {
+                options = new BundleOptions();
+                options.Configure(hostingEnvironment);
+            }
+
+            _bundleProvider = bundleProvider ?? new BundleProvider();
+            _options = options;
+            _hostingEnvironment = hostingEnvironment;
+            _cache = cache;
+            _htmlEncoder = htmlEncoder;
+            _urlHelperFactory = urlHelperFactory;
+        }
+
+        [HtmlAttributeNotBound]
+        [ViewContext]
+        public ViewContext ViewContext { get; set; }
+
+        [HtmlAttributeName("name")]
+        public string BundleName { get; set; }
+
+        public override void Process(TagHelperContext context, TagHelperOutput output)
+        {
+            output.SuppressOutput();
+            var bundle = _bundleProvider.GetBundle(BundleName);
+            if (bundle != null)
+            {
+                var files = GetFiles(bundle);
+                foreach (var file in files)
+                {
+                    var src = GetSrc(file);
+                    if (src == null)
+                        continue;
+
+                    if (_options.AppendVersion)
+                    {
+                        src = GetVersionedSrc(src);
+                    }
+
+                    if (bundle.OutputFileUrl.EndsWith(".js", StringComparison.OrdinalIgnoreCase))
+                    {
+                        output.Content.AppendHtmlLine($"<script src=\"{_htmlEncoder.Encode(src)}\" type=\"text/javascript\"></script>");
+                    }
+                    else if (bundle.OutputFileUrl.EndsWith(".css", StringComparison.OrdinalIgnoreCase))
+                    {
+                        output.Content.AppendHtmlLine($"<link href=\"{_htmlEncoder.Encode(src)}\" rel=\"stylesheet\" />");
+                    }
+                }
+            }
+        }
+
+        private IEnumerable<string> GetFiles(Bundle bundle)
+        {
+            if (_options.UseBundles)
+            {
+                var bundlePath = bundle.OutputFileUrl;
+                if (_options.UseMinifiedFiles)
+                {
+                    var extension = Path.GetExtension(bundlePath);
+                    if (extension != null)
+                    {
+                        var minifiedPath = Path.ChangeExtension(bundlePath, ".min" + extension);
+                        if (File.Exists(minifiedPath))
+                        {
+                            bundlePath = minifiedPath;
+                        }
+                    }
+                }
+
+                return new[] { bundlePath };
+            }
+
+            return bundle.InputFileUrls;
+        }
+
+        private string GetVersionedSrc(string srcValue)
+        {
+            EnsureFileVersionProvider();
+
+            if (_options.AppendVersion)
+            {
+                srcValue = _fileVersionProvider.AddFileVersionToPath(srcValue);
+            }
+
+            return srcValue;
+        }
+
+        private void EnsureFileVersionProvider()
+        {
+            if (_fileVersionProvider == null)
+            {
+                _fileVersionProvider = new FileVersionProvider(_hostingEnvironment.WebRootFileProvider, _cache, ViewContext.HttpContext.Request.PathBase);
+            }
+        }
+
+        private string GetSrc(string path)
+        {
+            var root = FileHelpers.NormalizePath(_hostingEnvironment.WebRootPath.DemandTrailingPathSeparatorChar());
+            var filePath = FileHelpers.NormalizePath(path);
+            if (filePath.StartsWith(root))
+            {
+                var urlHelper = _urlHelperFactory.GetUrlHelper(ViewContext);
+                return urlHelper.Content("~/" + filePath.Substring(root.Length).Replace('\\', '/'));
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/BundlerMinifier.TagHelpers/BundlerMinifier.TagHelpers.csproj
+++ b/src/BundlerMinifier.TagHelpers/BundlerMinifier.TagHelpers.csproj
@@ -1,0 +1,15 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.TagHelpers" Version="2.0.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\BundlerMinifier.Core\BundlerMinifier.Core.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/BundlerMinifier.TagHelpers/BundlesProvider.cs
+++ b/src/BundlerMinifier.TagHelpers/BundlesProvider.cs
@@ -1,0 +1,94 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace BundlerMinifier.TagHelpers
+{
+    public class BundleProvider : IBundleProvider, IDisposable
+    {
+        private readonly object _lock = new object();
+        private readonly string _configurationPath;
+        private IList<Bundle> _bundles;
+        private FileSystemWatcher _fileWatcher;
+
+        public BundleProvider()
+            : this("bundleconfig.json")
+        {
+        }
+
+        public BundleProvider(string configurationPath)
+        {
+            if (configurationPath == null) throw new ArgumentNullException(nameof(configurationPath));
+
+            var fullPath = Path.GetFullPath(configurationPath);
+            var directory = Path.GetDirectoryName(fullPath);
+            var fileName = Path.GetFileName(fullPath);
+            _configurationPath = fullPath;
+
+            if (directory != null)
+            {
+                var watcher = new FileSystemWatcher(directory);
+                watcher.EnableRaisingEvents = true;
+                watcher.IncludeSubdirectories = false;
+                watcher.Filter = fileName;
+                watcher.Changed += (sender, args) => Reset();
+                watcher.Created += (sender, args) => Reset();
+                watcher.Deleted += (sender, args) => Reset();
+                _fileWatcher = watcher;
+            }
+        }
+
+        private void Reset()
+        {
+            _bundles = null;
+        }
+
+        private void LoadBundles()
+        {
+            if (_bundles == null)
+            {
+                lock (_lock)
+                {
+                    if (_bundles == null)
+                    {
+                        if (!BundleHandler.TryGetBundles(_configurationPath, out var bundles))
+                            throw new Exception("Unable to load bundles.");
+
+                        var result = new List<Bundle>();
+                        foreach (var bundle in bundles)
+                        {
+                            var b = new Bundle();
+                            b.Name = bundle.OutputFileName;
+                            b.OutputFileUrl = bundle.GetAbsoluteOutputFile();
+                            b.InputFileUrls = bundle.GetAbsoluteInputFiles().ToList();
+                            result.Add(b);
+                        }
+
+                        _bundles = result;
+                    }
+                }
+            }
+        }
+
+        public Bundle GetBundle(string name)
+        {
+            LoadBundles();
+
+            var bundle = _bundles.FirstOrDefault(b => string.Equals(b.Name, name, StringComparison.OrdinalIgnoreCase));
+            if (bundle != null)
+                return bundle;
+
+            return null;
+        }
+
+        public void Dispose()
+        {
+            if (_fileWatcher != null)
+            {
+                _fileWatcher.Dispose();
+                _fileWatcher = null;
+            }
+        }
+    }
+}

--- a/src/BundlerMinifier.TagHelpers/IBundleProvider.cs
+++ b/src/BundlerMinifier.TagHelpers/IBundleProvider.cs
@@ -1,0 +1,7 @@
+namespace BundlerMinifier.TagHelpers
+{
+    public interface IBundleProvider
+    {
+        Bundle GetBundle(string name);
+    }
+}


### PR DESCRIPTION
This PR add a TagHelper to use bundles declared in the `bundleconfig.json` file.

````html
<bundle name="wwwroot/css/bundle.min.css" />
<bundle name="wwwroot/js/bundle.min.js" />
````

In development environment it expands the bundle to all files, so you can easily debug your code.
In production environment it uses the bundle file.

Issues:
- #137 Add TagHelper support
- https://github.com/meziantou/Meziantou.AspNetCore.BundleTagHelpers/issues/3