### PR TITLE
Remove version no. from ReadMe Ext.Tools hyperlink

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ if you want to contribute to this project.
 
 For cloning and building this project yourself, make sure
 to install the
-[Extensibility Tools 2015](https://visualstudiogallery.msdn.microsoft.com/ab39a092-1343-46e2-b0f1-6a3f91155aa6)
+[Extensibility Tools](https://visualstudiogallery.msdn.microsoft.com/ab39a092-1343-46e2-b0f1-6a3f91155aa6)
 extension for Visual Studio which enables some features
 used by this project.
 


### PR DESCRIPTION
Remove specific Visual Studio version number (2015) from Extensibility Tools hyperlink in ReadMe file