### PR TITLE
Fix for "Unable to load bundles" while running using IIS Express

### DIFF
--- a/src/BundlerMinifier.TagHelpers/BundleTagHelper.cs
+++ b/src/BundlerMinifier.TagHelpers/BundleTagHelper.cs
@@ -36,7 +36,7 @@ namespace BundlerMinifier.TagHelpers
                 options.Configure(hostingEnvironment);
             }
 
-            _bundleProvider = bundleProvider ?? new BundleProvider();
+            _bundleProvider = bundleProvider ?? new BundleProvider(hostingEnvironment);
             _options = options;
             _hostingEnvironment = hostingEnvironment;
             _cache = cache;

--- a/src/BundlerMinifier.TagHelpers/BundlesProvider.cs
+++ b/src/BundlerMinifier.TagHelpers/BundlesProvider.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using Microsoft.AspNetCore.Hosting;
 
 namespace BundlerMinifier.TagHelpers
 {
@@ -12,16 +13,31 @@ namespace BundlerMinifier.TagHelpers
         private IList<Bundle> _bundles;
         private FileSystemWatcher _fileWatcher;
 
-        public BundleProvider()
-            : this("bundleconfig.json")
+
+        public BundleProvider() : this(null)
         {
         }
 
-        public BundleProvider(string configurationPath)
+        public BundleProvider(IHostingEnvironment hostingEnvironment)
+            : this("bundleconfig.json", hostingEnvironment)
+        {
+        }
+
+        public BundleProvider(string configurationPath, IHostingEnvironment hostingEnvironment)
         {
             if (configurationPath == null) throw new ArgumentNullException(nameof(configurationPath));
 
-            var fullPath = Path.GetFullPath(configurationPath);
+            string filePath;
+            if (hostingEnvironment != null && string.IsNullOrWhiteSpace(Path.GetDirectoryName(configurationPath)))
+            {
+                filePath = Path.Combine(hostingEnvironment.ContentRootPath, configurationPath);
+            }
+            else
+            {
+                filePath = configurationPath;
+            }
+
+            var fullPath = Path.GetFullPath(filePath);
             var directory = Path.GetDirectoryName(fullPath);
             var fileName = Path.GetFileName(fullPath);
             _configurationPath = fullPath;


### PR DESCRIPTION
This changes fixes the error described in issue 418. Added a new constructor with IHostingEnvironment parameter which helps to resolve the path for bundleconfig.json
https://github.com/madskristensen/BundlerMinifier/issues/418