### PR TITLE
Skip bundle minifying if all the inputs are older than the minified file

### DIFF
--- a/src/BundlerMinifier.Core/Bundle/Bundle.cs
+++ b/src/BundlerMinifier.Core/Bundle/Bundle.cs
@@ -54,6 +54,8 @@ namespace BundlerMinifier
             get { return Path.GetFileName(OutputFileName).Contains(".min."); }
         }
 
+        public DateTime MostRecentWrite { get; set; }
+
         /// <summary>
         /// Converts the relative output file to an absolute file path.
         /// </summary>

--- a/src/BundlerMinifier.Core/Bundle/BundleFileProcessor.cs
+++ b/src/BundlerMinifier.Core/Bundle/BundleFileProcessor.cs
@@ -129,7 +129,7 @@ namespace BundlerMinifier
             if (bundle.IsMinificationEnabled || bundle.IsGzipEnabled)
             {
                 var outputWriteTime = File.GetLastWriteTimeUtc(minFile);
-                if (bundle.MostRecentWrite < outputWriteTime)
+                if (!bundle.IsGzipEnabled && bundle.MostRecentWrite < outputWriteTime)
                     return false;
                 var result = BundleMinifier.MinifyBundle(bundle);
 

--- a/src/BundlerMinifier.Core/Bundle/BundleFileProcessor.cs
+++ b/src/BundlerMinifier.Core/Bundle/BundleFileProcessor.cs
@@ -128,8 +128,14 @@ namespace BundlerMinifier
 
             if (bundle.IsMinificationEnabled || bundle.IsGzipEnabled)
             {
+                var outputWriteTime = File.GetLastWriteTimeUtc(minFile);
+                if (bundle.MostRecentWrite < outputWriteTime)
+                    return false;
                 var result = BundleMinifier.MinifyBundle(bundle);
 
+                // If no change is detected, then the minFile is not modified, so we need to update the write time manually
+                if (!result.Changed && File.Exists(minFile))
+                    File.SetLastWriteTimeUtc(minFile, DateTime.UtcNow);
                 changed |= result.Changed;
 
                 if (bundle.IsMinificationEnabled && bundle.SourceMap && !string.IsNullOrEmpty(result.SourceMap))

--- a/src/BundlerMinifier.Core/Bundle/BundleHandler.cs
+++ b/src/BundlerMinifier.Core/Bundle/BundleHandler.cs
@@ -81,6 +81,7 @@ namespace BundlerMinifier
 
         public static void ProcessBundle(string baseFolder, Bundle bundle)
         {
+            DateTime mostRecentWrite = default(DateTime);
             StringBuilder sb = new StringBuilder();
             List<string> inputFiles = bundle.GetAbsoluteInputFiles();
 
@@ -102,6 +103,9 @@ namespace BundlerMinifier
                     {
                         content = FileHelpers.ReadAllText(file);
                     }
+                    var lastWriteFile = System.IO.File.GetLastWriteTimeUtc(file);
+                    if (mostRecentWrite < lastWriteFile)
+                        mostRecentWrite = lastWriteFile;
 
                     // adding new line only if there are more than 1 files
                     // otherwise we are preserving file integrity
@@ -112,6 +116,7 @@ namespace BundlerMinifier
                 }
             }
 
+            bundle.MostRecentWrite = mostRecentWrite;
             bundle.Output = sb.ToString();
         }
 

--- a/src/BundlerMinifier.Core/Minify/BundleMinifier.cs
+++ b/src/BundlerMinifier.Core/Minify/BundleMinifier.cs
@@ -15,7 +15,6 @@ namespace BundlerMinifier
             string file = bundle.GetAbsoluteOutputFile();
             string extension = Path.GetExtension(file).ToUpperInvariant();
             var minResult = new MinificationResult(file, null, null);
-
             if (!string.IsNullOrEmpty(bundle.Output) && bundle.IsMinificationEnabled)
             {
                 try


### PR DESCRIPTION
BundlerMinifier is adding 6 sec to our build time, even if no file have changed.
If a CS file is changed in our project and we rebuild, BundleMinifier is accounting for 30% of the build time.

This is a significant hurdle on the code/debug feedback loop in our project.

This PR skip minification if all the inputs are older than the existing minified file.