### PR TITLE
Separating Gzip for cleaner execution, adding skip minify test

### DIFF
--- a/src/BundlerMinifier.Core/Minify/BundleMinifier.cs
+++ b/src/BundlerMinifier.Core/Minify/BundleMinifier.cs
@@ -43,11 +43,6 @@ namespace BundlerMinifier
             {
                 OnErrorMinifyingFile(minResult);
             }
-            else if (bundle.IsGzipEnabled)
-            {
-                string minFile = bundle.IsMinificationEnabled ? GetMinFileName(bundle.GetAbsoluteOutputFile()) : bundle.GetAbsoluteOutputFile();
-                GzipFile(minFile, bundle, minResult);
-            }
 
             return minResult;
         }
@@ -135,16 +130,16 @@ namespace BundlerMinifier
         }
 
         [SuppressMessage("Microsoft.Usage", "CA2202:Do not dispose objects multiple times")]
-        private static void GzipFile(string sourceFile, Bundle bundle, MinificationResult result)
+        public static void GzipFile(string sourceFile, Bundle bundle, bool minificationChanged, string minifiedContent)
         {
             var gzipFile = sourceFile + ".gz";
-            var containsChanges = result.Changed || File.GetLastWriteTimeUtc(gzipFile) < File.GetLastWriteTimeUtc(sourceFile);
+            var containsChanges = minificationChanged || File.GetLastWriteTimeUtc(gzipFile) < File.GetLastWriteTimeUtc(sourceFile);
 
             OnBeforeWritingGzipFile(sourceFile, gzipFile, bundle, containsChanges);
-
+            
             if (containsChanges)
             {
-                byte[] buffer = Encoding.UTF8.GetBytes(result.MinifiedContent??bundle.Output);
+                byte[] buffer = Encoding.UTF8.GetBytes(minifiedContent ?? bundle.Output);
 
                 using (var fileStream = File.OpenWrite(gzipFile))
                 using (var gzipStream = new GZipStream(fileStream, CompressionLevel.Optimal))

--- a/src/BundlerMinifierTest/BundlerTest.cs
+++ b/src/BundlerMinifierTest/BundlerTest.cs
@@ -39,6 +39,7 @@ namespace BundlerMinifierTest
             File.Delete("../../../artifacts/file3.min.html");
             File.Delete("../../../artifacts/file3.min.js");
             File.Delete("../../../artifacts/file4.min.html");
+            File.Delete("../../../artifacts/test7.min.js");
         }
 
         [TestMethod]
@@ -181,6 +182,23 @@ namespace BundlerMinifierTest
 
             string htmlResult = File.ReadAllText("../../../artifacts/file4.min.html");
             Assert.AreEqual("<div class=\"bold\"><span><i class=\"fa fa-phone\"></i></span> <span>DEF</span></div>", htmlResult);
+        }
+
+        [TestMethod]
+        public void PreventDoubleProcessing()
+        {
+            var bundle = TEST_BUNDLE.Replace("test1", "test7");
+
+            var result = _processor.Process(bundle);
+            Assert.IsTrue(result);
+            var filePath = "../../../artifacts/test7.min.js";
+            Assert.IsTrue(File.Exists(filePath));
+            var firstFileTime = File.GetLastWriteTimeUtc(filePath);
+
+            result = _processor.Process(bundle);
+            Assert.IsFalse(result);
+            var secondFileTime = File.GetLastWriteTimeUtc(filePath);
+            Assert.AreEqual(firstFileTime, secondFileTime);
         }
     }
 }

--- a/src/BundlerMinifierTest/artifacts/test7.json
+++ b/src/BundlerMinifierTest/artifacts/test7.json
@@ -1,0 +1,12 @@
+﻿[
+  {
+    "outputFileName": "test7.min.js",
+    "inputFiles": [
+      "encoding.js",
+      "file1.js",
+      "file2.js",
+      "file3.js",
+      "minify.js"
+    ]
+  }
+]


### PR DESCRIPTION
I've separated Gzip from minification so that they can be executed separately.

I've also added test to check functionality that @NicolasDorier added - that minification doesn't execute multiple times. 

Please review changes @madskristensen and if everything is fine I can release next version. Are you OK with upping this to 3.0? I don't see that we have support for minor versions since format seems to be 2.9.[BUILD_NUMBER].