### PR TITLE
Support .NET Core 3.0 in global tool

### DIFF
--- a/src/BundlerMinifier.Core/BundlerMinifier.Core.csproj
+++ b/src/BundlerMinifier.Core/BundlerMinifier.Core.csproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <Version>1.0.0</Version>
-    <TargetFrameworks>netcoreapp1.0;net452;netcoreapp2.0;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp1.0;net452;netcoreapp2.0;netstandard2.0;netcoreapp3.0</TargetFrameworks>
     <DefineConstants>$(DefineConstants);DOTNET</DefineConstants>
     <AssemblyName>dotnet-bundle</AssemblyName>
     <OutputType>Exe</OutputType>

--- a/src/BundlerMinifier/BundlerMinifier.csproj
+++ b/src/BundlerMinifier/BundlerMinifier.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\common.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>net46;netstandard1.3;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>net46;netstandard1.3;netcoreapp2.0;netcoreapp3.0</TargetFrameworks>
     <Title>Bundler &amp; Minifier</Title>
     <PackageId>BuildBundlerMinifier</PackageId>
 


### PR DESCRIPTION
Add `netcoreapp3.0` as a supported target framework.

Relates to #442.