### PR TITLE
Add .netcoreapp3.0 support for the BundleTagHelper

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,8 +2,7 @@ image: Visual Studio 2017
 
 install:
   - ps: (new-object Net.WebClient).DownloadString("https://raw.github.com/madskristensen/ExtensionScripts/master/AppVeyor/vsix.ps1") | iex
-  - powershell -NoProfile -ExecutionPolicy unrestricted -Command "&{iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/dotnet/cli/release/2.0.0/scripts/obtain/dotnet-install.ps1'))}"
-  - ps: $urlCurrent = "https://download.microsoft.com/download/0/6/5/0656B047-5F2F-4281-A851-F30776F8616D/dotnet-dev-win-x64.2.0.0-preview1-005977.zip"
+  - ps: $urlCurrent = "https://download.visualstudio.microsoft.com/download/pr/a24f4f34-ada1-433a-a437-5bc85fc2576a/7e886d06729949c15c96fe7e70faa8ae/dotnet-sdk-3.0.100-win-x64.zip"
   - ps: $env:DOTNET_INSTALL_DIR = "$pwd\.dotnetsdk"
   - ps: mkdir $env:DOTNET_INSTALL_DIR -Force | Out-Null
   - ps: $tempFileCurrent = [System.IO.Path]::GetTempFileName()

--- a/src/BundlerMinifier.TagHelpers/BundleExtensions.cs
+++ b/src/BundlerMinifier.TagHelpers/BundleExtensions.cs
@@ -1,6 +1,9 @@
 using System;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
+#if NETSTANDARD2_0
+using IWebHostEnvironment = Microsoft.AspNetCore.Hosting.IHostingEnvironment;
+#endif
 
 namespace BundlerMinifier.TagHelpers
 {
@@ -16,7 +19,7 @@ namespace BundlerMinifier.TagHelpers
             services.AddSingleton<IBundleProvider, BundleProvider>();
             services.AddTransient<BundleOptions>(serviceProvider =>
             {
-                var env = serviceProvider.GetService<IHostingEnvironment>();
+                var env = serviceProvider.GetService<IWebHostEnvironment>();
 
                 var options = new BundleOptions();
                 options.Configure(env);

--- a/src/BundlerMinifier.TagHelpers/BundleOptions.cs
+++ b/src/BundlerMinifier.TagHelpers/BundleOptions.cs
@@ -1,4 +1,9 @@
 using Microsoft.AspNetCore.Hosting;
+#if NETSTANDARD2_0
+using IWebHostEnvironment = Microsoft.AspNetCore.Hosting.IHostingEnvironment;
+#else
+using Microsoft.Extensions.Hosting;
+#endif
 
 namespace BundlerMinifier.TagHelpers
 {
@@ -8,7 +13,7 @@ namespace BundlerMinifier.TagHelpers
         public bool UseMinifiedFiles { get; set; }
         public bool AppendVersion { get; set; }        
 
-        internal void Configure(IHostingEnvironment env)
+        internal void Configure(IWebHostEnvironment env)
         {
             if (env != null)
             {

--- a/src/BundlerMinifier.TagHelpers/BundleTagHelper.cs
+++ b/src/BundlerMinifier.TagHelpers/BundleTagHelper.cs
@@ -9,6 +9,9 @@ using Microsoft.AspNetCore.Mvc.Routing;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using Microsoft.AspNetCore.Razor.TagHelpers;
 using Microsoft.Extensions.Caching.Memory;
+#if NETSTANDARD2_0
+using IWebHostEnvironment = Microsoft.AspNetCore.Hosting.IHostingEnvironment;
+#endif
 
 namespace BundlerMinifier.TagHelpers
 {
@@ -17,13 +20,13 @@ namespace BundlerMinifier.TagHelpers
     {
         private readonly IBundleProvider _bundleProvider;
         private readonly BundleOptions _options;
-        private readonly IHostingEnvironment _hostingEnvironment;
+        private readonly IWebHostEnvironment _hostingEnvironment;
         private readonly IMemoryCache _cache;
         private readonly HtmlEncoder _htmlEncoder;
         private readonly IUrlHelperFactory _urlHelperFactory;
         private FileVersionProvider _fileVersionProvider;
 
-        public BundleTagHelper(IHostingEnvironment hostingEnvironment, IMemoryCache cache, HtmlEncoder htmlEncoder, IUrlHelperFactory urlHelperFactory, BundleOptions options = null, IBundleProvider bundleProvider = null)
+        public BundleTagHelper(IWebHostEnvironment hostingEnvironment, IMemoryCache cache, HtmlEncoder htmlEncoder, IUrlHelperFactory urlHelperFactory, BundleOptions options = null, IBundleProvider bundleProvider = null)
         {
             if (hostingEnvironment == null) throw new ArgumentNullException(nameof(hostingEnvironment));
             if (cache == null) throw new ArgumentNullException(nameof(cache));

--- a/src/BundlerMinifier.TagHelpers/BundlerMinifier.TagHelpers.csproj
+++ b/src/BundlerMinifier.TagHelpers/BundlerMinifier.TagHelpers.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;netcoreapp3.0</TargetFrameworks>
     
     <Authors>Gérald Barré, Mads Kristensen, RockstarDev</Authors>
     <Product>Bundler &amp; Minifier TagHelpers</Product>
@@ -14,8 +14,10 @@
     <!-- forces SDK to copy dependencies into build output to make packing easier -->
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
-
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' != 'netstandard2.0'">
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="Microsoft.AspNetCore.Mvc.TagHelpers" Version="2.0.4" />
   </ItemGroup>
 

--- a/src/BundlerMinifier.TagHelpers/BundlesProvider.cs
+++ b/src/BundlerMinifier.TagHelpers/BundlesProvider.cs
@@ -3,6 +3,9 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Microsoft.AspNetCore.Hosting;
+#if NETSTANDARD2_0
+using IWebHostEnvironment = Microsoft.AspNetCore.Hosting.IHostingEnvironment;
+#endif
 
 namespace BundlerMinifier.TagHelpers
 {
@@ -18,12 +21,12 @@ namespace BundlerMinifier.TagHelpers
         {
         }
 
-        public BundleProvider(IHostingEnvironment hostingEnvironment)
+        public BundleProvider(IWebHostEnvironment hostingEnvironment)
             : this("bundleconfig.json", hostingEnvironment)
         {
         }
 
-        public BundleProvider(string configurationPath, IHostingEnvironment hostingEnvironment)
+        public BundleProvider(string configurationPath, IWebHostEnvironment hostingEnvironment)
         {
             if (configurationPath == null) throw new ArgumentNullException(nameof(configurationPath));
 

--- a/src/BundlerMinifier.TagHelpers/Shims.cs
+++ b/src/BundlerMinifier.TagHelpers/Shims.cs
@@ -1,0 +1,28 @@
+﻿#if !NETSTANDARD2_0
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Security.Cryptography;
+
+// Copied from https://github.com/aspnet/Antiforgery/blob/release/2.1/src/Microsoft.AspNetCore.Antiforgery/Internal/CryptographyAlgorithms.cs
+namespace Microsoft.AspNetCore.Antiforgery.Internal
+{
+    public static class CryptographyAlgorithms
+    {
+        public static SHA256 CreateSHA256()
+        {
+            try
+            {
+                return SHA256.Create();
+            }
+            // SHA256.Create is documented to throw this exception on FIPS compliant machines.
+            // See: https://msdn.microsoft.com/en-us/library/z08hz7ad%28v=vs.110%29.aspx?f=255&MSPPError=-2147217396
+            catch (System.Reflection.TargetInvocationException)
+            {
+                // Fallback to a FIPS compliant SHA256 algorithm.
+                return new SHA256CryptoServiceProvider();
+            }
+        }
+    }
+}
+#endif


### PR DESCRIPTION
The bundle tag helper does not work on netcoreapp3.0 despite BundlerMinifier targetting netstandard20 which is supported by netcoreapp3.0.

Long story short, netstandard2.0 is using `ITagHelper` from `Microsoft.AspNetCore.Razor.Runtime` while netcoreapp3.0 is using `Microsoft.AspNetCore.Razor`.

However, `Microsoft.AspNetCore.Razor` is  no longer produced, it is now an integral part of the netcoreapp3.0 runtime. (You can see that the package has no 3.0 version on https://www.nuget.org/packages/Microsoft.AspNetCore.Razor/)

This is documented on this document, https://docs.microsoft.com/en-us/aspnet/core/migration/22-to-30?view=aspnetcore-3.0&tabs=visual-studio#remove-obsolete-package-references 

Also, we now use  `IWebHostEnvironment` instead of `IHostingEnvironment` to prevent this error on netcoreapp3.0:

```
BundleExtensions.cs(19,54): warning CS0618: 'IHostingEnvironment' is obsolete: 'This type is obsolete and will be removed in a future version. The recommended alternative is Microsoft.AspNetCore.Hosting.IWebHostEnvironment.' [C:\Sources\BundlerMinifier\src\BundlerMinifier.TagHelpers\BundlerMinifier.TagHelpers.csproj]
```

We don't need to impact the other projects which can target netstandard2.0.