### PR TITLE
Output directory instead of file.

### DIFF
--- a/src/BundlerMinifier.Core/Bundle/Bundle.cs
+++ b/src/BundlerMinifier.Core/Bundle/Bundle.cs
@@ -65,6 +65,31 @@ namespace BundlerMinifier
             return Path.Combine(folder, OutputFileName.NormalizePath());
         }
 
+        public List<string> GetAbsoluteBaseDirectories()
+        {
+            List<string> baseDirs = new List<string>();
+            string folder = new DirectoryInfo(Path.GetDirectoryName(FileName)).FullName;
+
+            foreach (var inputFile in InputFiles)
+            {
+                int globIndex = inputFile.IndexOf('*');
+
+                if (globIndex > -1)
+                {
+                    string relative = string.Empty;
+                    int last = inputFile.LastIndexOf('/', globIndex);
+
+                    if (last > -1)
+                        relative = inputFile.Substring(0, last + 1);
+
+                    string baseDir = new FileInfo(Path.Combine(folder, relative).NormalizePath()).FullName;
+                    baseDirs.Add(baseDir);
+
+                }
+            }
+            return baseDirs;
+        }
+
         /// <summary>
         /// Returns a list of absolute file paths of all matching input files.
         /// </summary>

--- a/src/BundlerMinifierTest/GlobbingTest.cs
+++ b/src/BundlerMinifierTest/GlobbingTest.cs
@@ -26,6 +26,12 @@ namespace BundlerMinifierTest
             File.Delete("../../../artifacts/globbing/out1.min.js");
             File.Delete("../../../artifacts/globbing/out2.js");
             File.Delete("../../../artifacts/globbing/out2.min.js");
+            var outDirectory = "../../../artifacts/out/";
+            if (Directory.Exists(outDirectory))
+            {
+                Directory.Delete(outDirectory, true);
+            }
+
         }
 
         [TestMethod, TestCategory("Globbing")]
@@ -64,6 +70,42 @@ namespace BundlerMinifierTest
             string out2Min = File.ReadAllText(new FileInfo("../../../artifacts/globbing/out2.min.js").FullName);
             Assert.AreEqual(out2Min, "var a=1,b=2;");
         }
+
+        [TestMethod, TestCategory("Globbing")]
+        public void BundleMultipleToOutputDirectory()
+        {
+            _processor.Process("../../../artifacts/globbingOutputDirectory.json");
+
+            string[] outFiles = Directory.GetFiles("../../../artifacts/out/","*", SearchOption.TopDirectoryOnly);
+            Assert.AreEqual(12, outFiles.Count());
+
+            string in1 = File.ReadAllText(new FileInfo("../../../artifacts/globbing/a.js").FullName);
+            string out1 = File.ReadAllText(new FileInfo("../../../artifacts/out/a.js").FullName);
+            Assert.AreEqual(out1, in1);
+
+            string out1Min = File.ReadAllText(new FileInfo("../../../artifacts/out/a.min.js").FullName);
+            Assert.AreEqual("var a=1;", out1Min);
+
+            string out2Min = File.ReadAllText(new FileInfo("../../../artifacts/out/foo.min.css").FullName);
+            Assert.AreEqual("body{background:url(../test2/image.png?foo=hat)}", out2Min);
+            
+        }
+
+        [TestMethod, TestCategory("Globbing")]
+        public void BundleMultipleToOutputDirectoryRecursive()
+        {
+            _processor.Process("../../../artifacts/globbingOutputDirectory.json");
+
+            string[] outFiles = Directory.GetFiles("../../../artifacts/out/", "*", SearchOption.AllDirectories);
+            Assert.AreEqual(14, outFiles.Count());
+
+            Assert.IsTrue(Directory.Exists("../../../artifacts/out/sub"));
+            Assert.IsTrue(File.Exists("../../../artifacts/out/sub/b.js"));
+
+            string out1Min = File.ReadAllText(new FileInfo("../../../artifacts/out/sub/b.min.js").FullName);
+            Assert.AreEqual("var b=2;", out1Min);
+        }
+
 
     }
 }

--- a/src/BundlerMinifierTest/artifacts/globbingOutputDirectory.json
+++ b/src/BundlerMinifierTest/artifacts/globbingOutputDirectory.json
@@ -1,0 +1,6 @@
+﻿[
+  {
+    "outputFileName": "out/",
+    "inputFiles": [ "globbing/**/*.*", "test2/*.*" ]
+  }
+]


### PR DESCRIPTION
Add support to specify an output directory instead of file, and process each file individually replicating the source folder structure on destination.

Useful when you don't want to bundle into one file but process many files and folders keeping the folder structure.