### PR TITLE
Support ignoreErrorList in bundle definitions and pass it to NUglify.

### DIFF
--- a/src/BundlerMinifier.Core/Minify/JavaScriptOptions.cs
+++ b/src/BundlerMinifier.Core/Minify/JavaScriptOptions.cs
@@ -39,6 +39,8 @@ namespace BundlerMinifier
             if (int.TryParse(indentSize, out size))
                 settings.IndentSize = size;
 
+            settings.IgnoreErrorList = GetValue(bundle, "ignoreErrorList", "");
+
             return settings;
         }
 


### PR DESCRIPTION
This is needed to minify some problematic libraries such as tsParticles.
Related: https://github.com/trullock/NUglify/issues/214