### PR TITLE
Elaborate on Error message when bundle path is not present

### DIFF
--- a/src/BundlerMinifier.TagHelpers/BundlesProvider.cs
+++ b/src/BundlerMinifier.TagHelpers/BundlesProvider.cs
@@ -72,7 +72,7 @@ namespace BundlerMinifier.TagHelpers
                     if (_bundles == null)
                     {
                         if (!BundleHandler.TryGetBundles(_configurationPath, out var bundles))
-                            throw new Exception("Unable to load bundles.");
+                            throw new Exception($"Unable to load bundles from {_configurationPath}.");
 
                         var result = new List<Bundle>();
                         foreach (var bundle in bundles)


### PR DESCRIPTION
Spent some time diagnosing issue in release package as bundleconfig.json wasnt tagged as "Content" "copy if newer" so not present in release folder, thought message could be improved slightly to help debug on hosting server environment.