### PR TITLE
Update and consolidate NUglify to v1.13.8

### DIFF
--- a/src/BundlerMinifier.Core/BundlerMinifier.Core.csproj
+++ b/src/BundlerMinifier.Core/BundlerMinifier.Core.csproj
@@ -29,7 +29,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="NUglify" Version="1.9.1" />
+    <PackageReference Include="NUglify" Version="1.13.8" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
   </ItemGroup>
 

--- a/src/BundlerMinifier/BundlerMinifier.csproj
+++ b/src/BundlerMinifier/BundlerMinifier.csproj
@@ -30,7 +30,7 @@
     <PackageReference Include="Microsoft.Build.Framework" Version="15.1.0-*" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="15.1.0-*" PrivateAssets="All" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" PrivateAssets="All" />
-    <PackageReference Include="NUglify" Version="1.13.6" PrivateAssets="All" />
+    <PackageReference Include="NUglify" Version="1.13.8" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.3'">

--- a/src/BundlerMinifierVsix/BundlerMinifierVsix.csproj
+++ b/src/BundlerMinifierVsix/BundlerMinifierVsix.csproj
@@ -258,8 +258,8 @@
       <HintPath>..\..\packages\NuGet.VisualStudio.3.5.0\lib\net45\NuGet.VisualStudio.dll</HintPath>
       <EmbedInteropTypes>True</EmbedInteropTypes>
     </Reference>
-    <Reference Include="NUglify, Version=1.9.1.0, Culture=neutral, PublicKeyToken=15bc7810aec21b5e, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NUglify.1.9.1\lib\net40\NUglify.dll</HintPath>
+    <Reference Include="NUglify, Version=1.13.8.0, Culture=neutral, PublicKeyToken=15bc7810aec21b5e, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NUglify.1.13.8\lib\net40\NUglify.dll</HintPath>
     </Reference>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />

--- a/src/BundlerMinifierVsix/packages.config
+++ b/src/BundlerMinifierVsix/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net46" />
   <package id="NuGet.VisualStudio" version="3.5.0" targetFramework="net46" />
-  <package id="NUglify" version="1.9.1" targetFramework="net46" />
+  <package id="NUglify" version="1.13.8" targetFramework="net46" />
 </packages>


### PR DESCRIPTION
Using the current nightly build from www.vsixgallery.com v3.2.465 throws an error during minification saying NUglify v1.13.6 can't be found.  [Issue #542](https://github.com/madskristensen/BundlerMinifier/issues/542#issue-828311616) has found that manual update of NUglify.dll to v1.13.6 fixes this issue.

There seems to be a discrepancy between versions of NUglify.  Two projects BundlerMinifier.Core and BundlerMinifierVsix are using v1.9.1 while BundlerMinifier is using v1.13.6.

This pull request updates all three projects to NUglify 1.13.8 for consistency.

This is my first time updating someone else's project and creating a pull request so I hope I'm doing this right :)