### PR TITLE
Add .NET 5.0 support

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,7 @@ image: Visual Studio 2017
 
 install:
   - ps: (new-object Net.WebClient).DownloadString("https://raw.github.com/madskristensen/ExtensionScripts/master/AppVeyor/vsix.ps1") | iex
-  - ps: $urlCurrent = "https://download.visualstudio.microsoft.com/download/pr/adeab8b1-1c44-41b2-b12a-156442f307e9/65ebf805366410c63edeb06e53959383/dotnet-sdk-3.1.201-win-x64.zip"
+  - ps: $urlCurrent = "https://download.visualstudio.microsoft.com/download/pr/989b7ad4-bdce-4c40-a323-7e348578867a/cb7c44c6b2a68063be8e991e8fe8a13d/dotnet-sdk-5.0.201-win-x64.zip"
   - ps: $env:DOTNET_INSTALL_DIR = "$pwd\.dotnetsdk"
   - ps: mkdir $env:DOTNET_INSTALL_DIR -Force | Out-Null
   - ps: $tempFileCurrent = [System.IO.Path]::GetTempFileName()

--- a/src/BundlerMinifier.Core/BundlerMinifier.Core.csproj
+++ b/src/BundlerMinifier.Core/BundlerMinifier.Core.csproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <Version>1.0.0</Version>
-    <TargetFrameworks>netcoreapp1.0;net452;netcoreapp2.0;netstandard2.0;netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp1.0;net452;netcoreapp2.0;netstandard2.0;netcoreapp3.0;netcoreapp3.1;net5.0</TargetFrameworks>
     <DefineConstants>$(DefineConstants);DOTNET</DefineConstants>
     <AssemblyName>dotnet-bundle</AssemblyName>
     <OutputType>Exe</OutputType>

--- a/src/BundlerMinifier.TagHelpers/BundlerMinifier.TagHelpers.csproj
+++ b/src/BundlerMinifier.TagHelpers/BundlerMinifier.TagHelpers.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netcoreapp3.0;netcoreapp3.1;net5.0</TargetFrameworks>
     
     <Authors>Gérald Barré, Mads Kristensen, RockstarDev</Authors>
     <Product>Bundler &amp; Minifier TagHelpers</Product>

--- a/src/BundlerMinifier/BundlerMinifier.csproj
+++ b/src/BundlerMinifier/BundlerMinifier.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\common.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>net46;netstandard1.3;netcoreapp2.0;netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net46;netstandard1.3;netcoreapp2.0;netcoreapp3.0;netcoreapp3.1;net5.0</TargetFrameworks>
     <Title>Bundler &amp; Minifier</Title>
     <PackageId>BuildBundlerMinifier</PackageId>
 


### PR DESCRIPTION
Adds .NET 5.0 as a supported target framework.

Relates to [#460](https://github.com/madskristensen/BundlerMinifier/issues/460).