### PR TITLE
Added decode escapes option

### DIFF
--- a/src/BundlerMinifier.Core/Minify/CssOptions.cs
+++ b/src/BundlerMinifier.Core/Minify/CssOptions.cs
@@ -9,6 +9,7 @@ namespace BundlerMinifier
         {
             CssSettings settings = new CssSettings();
             settings.TermSemicolons = GetValue(bundle, "termSemicolons") == "True";
+            settings.DecodeEscapes = GetValue(bundle, "decodeEscapes", "True") == "True";
 
             string cssComment = GetValue(bundle, "commentMode");
 


### PR DESCRIPTION
Encoding escaped characters into unicode chars can sometimes cause arcane issues with icon fonts: https://github.com/FortAwesome/Font-Awesome/issues/17644

This option lets you turn off escape encoding.

Is it possible to get a new release of the BuildBundlerMinifier nuget, or do we need to fork that? I'm not seeing a nightly build of the nuget, only the visx.